### PR TITLE
move send to gosnmp.go, fix errorf in marshal.go

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -10,10 +10,13 @@ package gosnmp
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"math/big"
 	"math/rand"
 	"net"
 	"strconv"
+	"sync/atomic"
 	"time"
 )
 
@@ -142,6 +145,105 @@ func (x *GoSNMP) Connect() error {
 	}
 	x.requestID = x.random.Uint32()
 	return nil
+}
+
+// generic "sender"
+func (x *GoSNMP) send(pdus []SnmpPDU, packetOut *SnmpPacket) (result *SnmpPacket, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("recover: %v", e)
+		}
+	}()
+
+	if x.Conn == nil {
+		return nil, fmt.Errorf("&GoSNMP.Conn is missing. Provide a connection or use Connect()")
+	}
+
+	if x.Logger == nil {
+		x.Logger = log.New(ioutil.Discard, "", 0)
+	}
+	slog = x.Logger // global variable for debug logging
+
+	finalDeadline := time.Now().Add(x.Timeout)
+
+	if x.Retries < 0 {
+		x.Retries = 0
+	}
+	allReqIDs := make([]uint32, 0, x.Retries+1)
+	for retries := 0; ; retries++ {
+		if retries > 0 {
+			if LoggingDisabled != true {
+				slog.Printf("Retry number %d. Last error was: %v", retries, err)
+			}
+			if time.Now().After(finalDeadline) {
+				err = fmt.Errorf("Request timeout (after %d retries)", retries-1)
+				break
+			}
+			if retries > x.Retries {
+				// Report last error
+				break
+			}
+		}
+		err = nil
+
+		reqDeadline := time.Now().Add(x.Timeout / time.Duration(x.Retries+1))
+		x.Conn.SetDeadline(reqDeadline)
+
+		// Request ID is an atomic counter (started at a random value)
+		reqID := atomic.AddUint32(&(x.requestID), 1)
+		allReqIDs = append(allReqIDs, reqID)
+
+		var outBuf []byte
+		outBuf, err = packetOut.marshalMsg(pdus, packetOut.PDUType, reqID)
+		if err != nil {
+			// Don't retry - not going to get any better!
+			err = fmt.Errorf("marshal: %v", err)
+			break
+		}
+		_, err = x.Conn.Write(outBuf)
+		if err != nil {
+			err = fmt.Errorf("Error writing to socket: %s", err.Error())
+			continue
+		}
+
+		// FIXME: If our packet exceeds our buf size we'll get a partial read
+		// and this request, and the next will fail. The correct logic would be
+		// to realloc and read more if pack len > buff size.
+		resp := make([]byte, rxBufSize, rxBufSize)
+		var n int
+		n, err = x.Conn.Read(resp)
+		if err != nil {
+			err = fmt.Errorf("Error reading from UDP: %s", err.Error())
+			continue
+		}
+
+		result, err = unmarshal(resp[:n])
+		if err != nil {
+			err = fmt.Errorf("Unable to decode packet: %s", err.Error())
+			continue
+		}
+		if result == nil || len(result.Variables) < 1 {
+			err = fmt.Errorf("Unable to decode packet: nil")
+			continue
+		}
+
+		validID := false
+		for _, id := range allReqIDs {
+			if id == result.RequestID {
+				validID = true
+			}
+		}
+		if !validID {
+			err = fmt.Errorf("Out of order response")
+			continue
+		}
+
+		// Success!
+		return result, nil
+	}
+
+	// Return last error
+	return nil, err
 }
 
 // Get sends an SNMP GET request

--- a/marshal.go
+++ b/marshal.go
@@ -9,10 +9,6 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"sync/atomic"
-	"time"
 )
 
 //
@@ -83,105 +79,6 @@ type Logger interface {
 
 // slog is a global variable that is used for debug logging
 var slog Logger
-
-// generic "sender"
-func (x *GoSNMP) send(pdus []SnmpPDU, packetOut *SnmpPacket) (result *SnmpPacket, err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("recover: %v", e)
-		}
-	}()
-
-	if x.Conn == nil {
-		return nil, fmt.Errorf("&GoSNMP.Conn is missing. Provide a connection or use Connect()")
-	}
-
-	if x.Logger == nil {
-		x.Logger = log.New(ioutil.Discard, "", 0)
-	}
-	slog = x.Logger // global variable for debug logging
-
-	finalDeadline := time.Now().Add(x.Timeout)
-
-	if x.Retries < 0 {
-		x.Retries = 0
-	}
-	allReqIDs := make([]uint32, 0, x.Retries+1)
-	for retries := 0; ; retries++ {
-		if retries > 0 {
-			if LoggingDisabled != true {
-				slog.Printf("Retry number %d. Last error was: %v", retries, err)
-			}
-			if time.Now().After(finalDeadline) {
-				err = fmt.Errorf("Request timeout (after %d retries)", retries-1)
-				break
-			}
-			if retries > x.Retries {
-				// Report last error
-				break
-			}
-		}
-		err = nil
-
-		reqDeadline := time.Now().Add(x.Timeout / time.Duration(x.Retries+1))
-		x.Conn.SetDeadline(reqDeadline)
-
-		// Request ID is an atomic counter (started at a random value)
-		reqID := atomic.AddUint32(&(x.requestID), 1)
-		allReqIDs = append(allReqIDs, reqID)
-
-		var outBuf []byte
-		outBuf, err = packetOut.marshalMsg(pdus, packetOut.PDUType, reqID)
-		if err != nil {
-			// Don't retry - not going to get any better!
-			err = fmt.Errorf("marshal: %v", err)
-			break
-		}
-		_, err = x.Conn.Write(outBuf)
-		if err != nil {
-			err = fmt.Errorf("Error writing to socket: %s", err.Error())
-			continue
-		}
-
-		// FIXME: If our packet exceeds our buf size we'll get a partial read
-		// and this request, and the next will fail. The correct logic would be
-		// to realloc and read more if pack len > buff size.
-		resp := make([]byte, rxBufSize, rxBufSize)
-		var n int
-		n, err = x.Conn.Read(resp)
-		if err != nil {
-			err = fmt.Errorf("Error reading from UDP: %s", err.Error())
-			continue
-		}
-
-		result, err = unmarshal(resp[:n])
-		if err != nil {
-			err = fmt.Errorf("Unable to decode packet: %s", err.Error())
-			continue
-		}
-		if result == nil || len(result.Variables) < 1 {
-			err = fmt.Errorf("Unable to decode packet: nil")
-			continue
-		}
-
-		validID := false
-		for _, id := range allReqIDs {
-			if id == result.RequestID {
-				validID = true
-			}
-		}
-		if !validID {
-			err = fmt.Errorf("Out of order response")
-			continue
-		}
-
-		// Success!
-		return result, nil
-	}
-
-	// Return last error
-	return nil, err
-}
 
 // -- Marshalling Logic --------------------------------------------------------
 
@@ -381,7 +278,7 @@ func unmarshal(packet []byte) (*SnmpPacket, error) {
 			return nil, fmt.Errorf("Error in unmarshalResponse: %s", err.Error())
 		}
 	default:
-		return nil, fmt.Errorf("Unknown PDUType %#x")
+		return nil, fmt.Errorf("Unknown PDUType %#x", requestType)
 	}
 	return response, nil
 }


### PR DESCRIPTION
It seems to make sense to have all of the functions operating on "x *GoSNMP" in the same file... 