### PR TITLE
very subtle scoping issue

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -141,7 +141,7 @@ func (x *GoSNMP) send(pdus []SnmpPDU, packetOut *SnmpPacket) (result *SnmpPacket
 		}
 
 		var resp []byte
-		resp, err := dispatch(x.Conn, outBuf, len(pdus))
+		resp, err = dispatch(x.Conn, outBuf, len(pdus))
 		if err != nil {
 			return result, err
 		}


### PR DESCRIPTION
The err variable was erroneously (re)created in the scope of the loop body. While this didn't affect returning it from the loop, the non-fatal err assignments from the loop to the outer scope variable were now masked, resulting in (nil, nil) function returns, which causes a panic in walk.go:47 when a field in the nil result is accessed.