### PR TITLE
Add community argument to walkexample

### DIFF
--- a/examples/walkexample.go
+++ b/examples/walkexample.go
@@ -16,23 +16,26 @@ import (
 
 func usage() {
 	fmt.Println("Usage:")
-	fmt.Printf("   %s host [oid]\n", filepath.Base(os.Args[0]))
-	fmt.Println("     host - the host to walk/scan")
-	fmt.Println("     oid  - the MIB/Oid defining a subtree of values")
+	fmt.Printf("   %s host community [oid]\n", filepath.Base(os.Args[0]))
+	fmt.Println("     host      - the host to walk/scan")
+	fmt.Println("     community - the community string for device")
+	fmt.Println("     oid       - the MIB/Oid defining a subtree of values")
 	os.Exit(1)
 }
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 3 {
 		usage()
 	}
 	target := os.Args[1]
+	community := os.Args[2]
 	var oid string
-	if len(os.Args) > 2 {
-		oid = os.Args[2]
+	if len(os.Args) > 3 {
+		oid = os.Args[3]
 	}
 
 	gosnmp.Default.Target = target
+	gosnmp.Default.Community = community
 	gosnmp.Default.Timeout = time.Duration(10 * time.Second) // Timeout better suited to walking
 	err := gosnmp.Default.Connect()
 	if err != nil {


### PR DESCRIPTION
This example is a very quick test to confirm
a device can be walked successfully. As most devices
don't have a default community string of "public", better
to make it an extra arg to facilitate testing.