### PR TITLE
Fix integer zero value encoding

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -266,7 +266,7 @@ func marshalUvarInt(x uint32) []byte {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, x)
 	i := 0
-	for ; i < 4; i++ {
+	for ; i < 3; i++ {
 		if buf[i] != 0 {
 			break
 		}


### PR DESCRIPTION
ITU X.690 8.3.1 says that integers should be encoded into 1 or more octets; gosnmp currently encodes zero-value integers into 0 octets, which causes it to fail miserably on certain enterprise-grade devices. Associated pull request fixes this issue.