### PR TITLE
handle receiving duplicate packets

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -90,6 +90,8 @@ type GoSNMP struct {
 	requestID uint32
 	random    *rand.Rand
 
+	rxBuf *[rxBufSize]byte // has to be pointer due to https://github.com/golang/go/issues/11728
+
 	// Internal - used to sync requests to responses - snmpv3
 	msgID uint32
 }
@@ -195,6 +197,8 @@ func (x *GoSNMP) Connect() error {
 	x.msgID = uint32(x.random.Int31())
 	// RequestID is Integer32 from SNMPV2-SMI and uses all 32 bits
 	x.requestID = x.random.Uint32()
+
+	x.rxBuf = new([rxBufSize]byte)
 
 	if x.Version == Version3 {
 		x.MsgFlags |= Reportable // tell the snmp server that a report PDU MUST be sent


### PR DESCRIPTION
fixes #68 


----

As an unrelated note, it happens at numerous places in the code where a method is called on a struct, and is passed members of itself as arguments.
For example in the previous code that this PR replaced:

    x.dispatch(x.Conn, outBuf, expected)

Why not have the `dispatch` method just access `x.Conn` itself instead of passing it?

Other example:

    packetOut.marshalMsg(pdus, packetOut.PDUType, msgID, reqID)

`packetOut` is a [SnmpPacket](https://godoc.org/github.com/soniah/gosnmp#SnmpPacket) in which `.Variables` can replace the `pdus` argument. `.PDUType` can replace the `packetOut.PDUType` argument, `.MsgID` can replace the `msgID` argument, and `.RequestID` can replace the `reqID` argument.

And numerous similar examples.

I think it would make the code easier for contributors to work with if these were cleaned up. I personally found it highly confusing trying to figure out why this was being done.