### PR TITLE
Skip the test suite if the environment variables are missing

### DIFF
--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -25,12 +25,12 @@ func setupConnection(t *testing.T) {
 	envPort := os.Getenv("GOSNMP_PORT")
 
 	if len(envTarget) <= 0 {
-		t.Fatalf("environment variable not set: GOSNMP_TARGET")
+		t.Skip("skipping: environment variable not set: GOSNMP_TARGET")
 	}
 	Default.Target = envTarget
 
 	if len(envPort) <= 0 {
-		t.Fatalf("environment variable not set: GOSNMP_PORT")
+		t.Skip("skipping: environment variable not set: GOSNMP_PORT")
 	}
 	port, _ := strconv.ParseUint(envPort, 10, 16)
 	Default.Port = uint16(port)


### PR DESCRIPTION
Requiring a running and functional SNMPd on the system is a problematic
requirement in many environments (such as distribution build networks),
and might conflict with running instances that cannot be reconfigured.

I stumbled on this when preparing Debian packages for this project.
