### PR TITLE
Add V1 traps, fix examples, fix TrapListener logging

### DIFF
--- a/examples/trapserver.go
+++ b/examples/trapserver.go
@@ -15,11 +15,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	g "github.com/soniah/gosnmp"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
+
+	g "github.com/soniah/gosnmp"
 )
 
 func main() {
@@ -29,13 +30,11 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	params := g.Default
-	params.Logger = log.New(os.Stdout, "", 0)
+	tl := g.NewTrapListener()
+	tl.OnNewTrap = myTrapHandler
+	tl.Params = g.Default
+	tl.Params.Logger = log.New(os.Stdout, "", 0)
 
-	tl := g.TrapListener{
-		OnNewTrap: myTrapHandler,
-		Params:    params,
-	}
 	err := tl.Listen("0.0.0.0:9162")
 	if err != nil {
 		log.Panicf("error in listen: %s", err)

--- a/marshal.go
+++ b/marshal.go
@@ -49,6 +49,13 @@ type SnmpPacket struct {
 	MaxRepetitions     uint8
 	Variables          []SnmpPDU
 	Logger             Logger
+
+	// Trap V1 header
+	Enterprise   []int
+	AgentAddr    string
+	GenericTrap  int
+	SpecificTrap int
+	Timestamp    int
 }
 
 // VarBind struct represents an SNMP Varbind.
@@ -638,6 +645,12 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 		if err != nil {
 			return fmt.Errorf("Error in unmarshalResponse: %s", err.Error())
 		}
+	case Trap:
+		response.PDUType = requestType
+		err = x.unmarshalTrapV1(packet[cursor:], response)
+		if err != nil {
+			return fmt.Errorf("Error in unmarshalTrapV1: %s", err.Error())
+		}
 	default:
 		return fmt.Errorf("Unknown PDUType %#x", requestType)
 	}
@@ -706,6 +719,73 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 			response.ErrorIndex = uint8(errorindex)
 			x.logPrintf("error-index: %d", uint8(errorindex))
 		}
+	}
+
+	return x.unmarshalVBL(packet[cursor:], response)
+}
+
+func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
+	cursor := 0
+
+	getResponseLength, cursor := parseLength(packet)
+	if len(packet) != getResponseLength {
+		return fmt.Errorf("Error verifying Response sanity: Got %d Expected: %d\n", len(packet), getResponseLength)
+	}
+	x.logPrintf("getResponseLength: %d", getResponseLength)
+
+	// Parse Enterprise
+	rawEnterprise, count, err := parseRawField(packet[cursor:], "enterprise")
+	if err != nil {
+		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
+	}
+	cursor += count
+	if Enterpise, ok := rawEnterprise.([]int); ok {
+		response.Enterprise = Enterpise
+		x.logPrintf("Enterprise: %+v", Enterpise)
+	}
+
+	// Parse AgentAddr
+	rawAgentAddr, count, err := parseRawField(packet[cursor:], "agent-addr")
+	if err != nil {
+		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
+	}
+	cursor += count
+	if AgentAddr, ok := rawAgentAddr.(string); ok {
+		response.AgentAddr = AgentAddr
+		x.logPrintf("AgentAddr: %s", AgentAddr)
+	}
+
+	// Parse GenericTrap
+	rawGenericTrap, count, err := parseRawField(packet[cursor:], "generic-trap")
+	if err != nil {
+		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
+	}
+	cursor += count
+	if GenericTrap, ok := rawGenericTrap.(int); ok {
+		response.GenericTrap = GenericTrap
+		x.logPrintf("GenericTrap: %d", GenericTrap)
+	}
+
+	// Parse SpecificTrap
+	rawSpecificTrap, count, err := parseRawField(packet[cursor:], "specific-trap")
+	if err != nil {
+		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
+	}
+	cursor += count
+	if SpecificTrap, ok := rawSpecificTrap.(int); ok {
+		response.SpecificTrap = SpecificTrap
+		x.logPrintf("SpecificTrap: %d", SpecificTrap)
+	}
+
+	// Parse TimeStamp
+	rawTimestamp, count, err := parseRawField(packet[cursor:], "time-stamp")
+	if err != nil {
+		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
+	}
+	cursor += count
+	if Timestamp, ok := rawTimestamp.(int); ok {
+		response.Timestamp = Timestamp
+		x.logPrintf("Timestamp: %d", Timestamp)
 	}
 
 	return x.unmarshalVBL(packet[cursor:], response)

--- a/trap.go
+++ b/trap.go
@@ -99,6 +99,7 @@ func (t *TrapListener) Listen(addr string) (err error) {
 	if t.Params == nil {
 		t.Params = Default
 	}
+	t.Params.validateParameters()
 
 	if t.OnNewTrap == nil {
 		t.OnNewTrap = debugTrapHandler


### PR DESCRIPTION
1. Trap example panics because TrapListener.c *sync.Cond is nil, switch to NewTrapListener()
2. TrapListener does not log anything because validateParameters() isn't called in Listen(). Fix this.
3. Add support for receiving V1 traps