### PR TITLE
Fix runtime integer divide by zero error.

### DIFF
--- a/v3_usm.go
+++ b/v3_usm.go
@@ -185,14 +185,17 @@ func castUsmSecParams(secParams SnmpV3SecurityParameters) (*UsmSecurityParameter
 // MD5 HMAC key calculation algorithm
 func md5HMAC(password string, engineID string) []byte {
 	comp := md5.New()
-	var pi int // password index
-	for i := 0; i < 1048576; i += 64 {
-		var chunk []byte
-		for e := 0; e < 64; e++ {
-			chunk = append(chunk, password[pi%len(password)])
-			pi++
+	plen := len(password)
+	if plen > 0 {
+		var pi int // password index
+		for i := 0; i < 1048576; i += 64 {
+			var chunk []byte
+			for e := 0; e < 64; e++ {
+				chunk = append(chunk, password[pi%plen])
+				pi++
+			}
+			comp.Write(chunk)
 		}
-		comp.Write(chunk)
 	}
 	compressed := comp.Sum(nil)
 	local := md5.New()
@@ -206,14 +209,17 @@ func md5HMAC(password string, engineID string) []byte {
 // SHA HMAC key calculation algorithm
 func shaHMAC(password string, engineID string) []byte {
 	hash := sha1.New()
-	var pi int // password index
-	for i := 0; i < 1048576; i += 64 {
-		var chunk []byte
-		for e := 0; e < 64; e++ {
-			chunk = append(chunk, password[pi%len(password)])
-			pi++
+	plen := len(password)
+	if plen > 0 {
+		var pi int // password index
+		for i := 0; i < 1048576; i += 64 {
+			var chunk []byte
+			for e := 0; e < 64; e++ {
+				chunk = append(chunk, password[pi%plen])
+				pi++
+			}
+			hash.Write(chunk)
 		}
-		hash.Write(chunk)
 	}
 	hashed := hash.Sum(nil)
 	local := sha1.New()


### PR DESCRIPTION
This fixes `runtime error: integer divide by zero`, found in https://github.com/prometheus/snmp_exporter/issues/185 when private password is empty string. 

More detailed debug details can be found in my comment at https://github.com/prometheus/snmp_exporter/issues/185#issuecomment-328992935