### PR TITLE
More correctly marshal varbinds for Null PDUs with long OIDs

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -440,11 +440,22 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 	switch pdu.Type {
 
 	case Null:
-		pduBuf.Write([]byte{byte(Sequence), byte(len(oid) + 4)})
-		pduBuf.Write([]byte{byte(ObjectIdentifier), byte(len(oid))})
-		pduBuf.Write(oid)
-		pduBuf.Write([]byte{Null, 0x00})
+		ltmp, err := marshalLength(len(oid))
+		if err != nil {
+			return nil, err
+		}
+		tmpBuf.Write([]byte{byte(ObjectIdentifier)})
+		tmpBuf.Write(ltmp)
+		tmpBuf.Write(oid)
+		tmpBuf.Write([]byte{Null, 0x00})
 
+		ltmp, err = marshalLength(tmpBuf.Len())
+		if err != nil {
+			return nil, err
+		}
+		pduBuf.Write([]byte{byte(Sequence)})
+		pduBuf.Write(ltmp)
+		tmpBuf.WriteTo(pduBuf)
 	/*
 		NUMBERS:
 


### PR DESCRIPTION
I was running into odd hangs while trying to getbulk firewall counters from a junos device. gosnmp was generating invalid snmp requests for OIDs with >= 127 parts. Some diffing with captures from the command line tools lead me to the lengths. Unfortunately I don't have time to understand ASN.1 and BER encoding in depth so this fix may be incomplete. I guess I'll add the obligatory "it works for my use case" warning.