### PR TITLE
Add support for SNMP v1 traps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ gosnmp.html
 cpu.out
 mem.out
 gosnmp.test
+
+.idea/

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -115,7 +115,6 @@ var Default = &GoSNMP{
 
 // SnmpPDU will be used when doing SNMP Set's
 type SnmpPDU struct {
-
 	// Name is an oid in string format eg ".1.3.6.1.4.9.27"
 	Name string
 
@@ -250,6 +249,20 @@ func (x *GoSNMP) validateParameters() error {
 	return nil
 }
 
+func (x *GoSNMP) mkSnmpPacketV1(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacketV1 {
+	return &SnmpPacketV1{
+		Version:      x.Version,
+		Community:    x.Community,
+		PDUType:      pdutype,
+		Enterprise:   enterprise,
+		AgentAddr:    agentAddress,
+		GenericTrap:  genericTrap,
+		SpecificTrap: specificTrap,
+		Timestamp:    timestamp,
+		Variables:    pdus,
+	}
+}
+
 func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) *SnmpPacket {
 	var newSecParams SnmpV3SecurityParameters
 	if x.SecurityParameters != nil {
@@ -269,20 +282,6 @@ func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint
 		NonRepeaters:       nonRepeaters,
 		MaxRepetitions:     maxRepetitions,
 		Variables:          pdus,
-	}
-}
-
-func (x *GoSNMP) mkSnmpPacketV1Trap(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacket {
-	return &SnmpPacket{
-		Version:      x.Version,
-		Community:    x.Community,
-		PDUType:      pdutype,
-		Enterprise:   enterprise,
-		AgentAddr:    agentAddress,
-		GenericTrap:  genericTrap,
-		SpecificTrap: specificTrap,
-		Timestamp:    timestamp,
-		Variables:    pdus,
 	}
 }
 
@@ -454,7 +453,7 @@ func ToBigInt(value interface{}) *big.Int {
 	case uint32:
 		val = int64(value)
 	case uint64:
-		return (uint64ToBigInt(value))
+		return uint64ToBigInt(value)
 	case string:
 		// for testing and other apps - numbers may appear as strings
 		var err error

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -249,20 +249,6 @@ func (x *GoSNMP) validateParameters() error {
 	return nil
 }
 
-func (x *GoSNMP) mkSnmpPacketV1Trap(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacket {
-	return &SnmpPacket{
-		Version:      x.Version,
-		Community:    x.Community,
-		PDUType:      pdutype,
-		Enterprise:   enterprise,
-		AgentAddr:    agentAddress,
-		GenericTrap:  genericTrap,
-		SpecificTrap: specificTrap,
-		Timestamp:    timestamp,
-		Variables:    pdus,
-	}
-}
-
 func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) *SnmpPacket {
 	var newSecParams SnmpV3SecurityParameters
 	if x.SecurityParameters != nil {

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -249,8 +249,8 @@ func (x *GoSNMP) validateParameters() error {
 	return nil
 }
 
-func (x *GoSNMP) mkSnmpPacketV1(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacketV1 {
-	return &SnmpPacketV1{
+func (x *GoSNMP) mkSnmpPacketV1Trap(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacket {
+	return &SnmpPacket{
 		Version:      x.Version,
 		Community:    x.Community,
 		PDUType:      pdutype,
@@ -453,7 +453,7 @@ func ToBigInt(value interface{}) *big.Int {
 	case uint32:
 		val = int64(value)
 	case uint64:
-		return uint64ToBigInt(value)
+		return (uint64ToBigInt(value))
 	case string:
 		// for testing and other apps - numbers may appear as strings
 		var err error

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -272,6 +272,20 @@ func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint
 	}
 }
 
+func (x *GoSNMP) mkSnmpPacketV1Trap(pdutype PDUType, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int, pdus []SnmpPDU) *SnmpPacket {
+	return &SnmpPacket{
+		Version:      x.Version,
+		Community:    x.Community,
+		PDUType:      pdutype,
+		Enterprise:   enterprise,
+		AgentAddr:    agentAddress,
+		GenericTrap:  genericTrap,
+		SpecificTrap: specificTrap,
+		Timestamp:    timestamp,
+		Variables:    pdus,
+	}
+}
+
 // Get sends an SNMP GET request
 func (x *GoSNMP) Get(oids []string) (result *SnmpPacket, err error) {
 	oidCount := len(oids)

--- a/marshal.go
+++ b/marshal.go
@@ -505,6 +505,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 		snmp Counter32, Gauge32, TimeTicks, Unsigned32:
 		non-negative integer, maximum value of 2^32-1 (4294967295 decimal)
 	*/
+
 	case Integer:
 		// TODO tests currently only cover positive integers
 

--- a/marshal.go
+++ b/marshal.go
@@ -410,9 +410,11 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		// requestid
 		buf.Write([]byte{2, 4})
 		err := binary.Write(buf, binary.BigEndian, packet.RequestID)
+
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Unable to marshal OID: %s\n", err.Error())
 		}
+
 		// error
 		buf.Write([]byte{2, 1, 0})
 

--- a/trap.go
+++ b/trap.go
@@ -60,6 +60,41 @@ func (x *GoSNMP) SendTrap(pdus []SnmpPDU) (result *SnmpPacket, err error) {
 	return x.send(packetOut, false)
 }
 
+/*
+Good practice is to send a struct rather than many parameters (Golang and other languages too). Please change :-)
+
+- it's easier to understand
+- if new parameters need to be added, you can do it without changing the (public) method signature
+
+I would suggest something like:
+func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, niceVariableName NiceStructName) (result *SnmpPacket, err error) {
+  ....
+}
+
+See Connect() in gosnmp.go for an example (though there *GoSNMP
+provides a method on a struct type)
+*/
+func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int) (result *SnmpPacket, err error) {
+	switch x.Version {
+	case Version2c, Version3:
+		err = fmt.Errorf("SendV1Trap doesn't support %s", x.Version)
+		return nil, err
+	default:
+		// do nothing
+	}
+
+	if len(pdus) == 0 {
+		return nil, fmt.Errorf("SendV1Trap requires at least 1 pdu")
+	}
+
+	// TODO this function shouldn't exist, just build a struct here.
+	// mkSnmpPacket() has some logic in it (SecurityParameters.Copy(),
+	// hence need for a separate method
+	packetOut := x.mkSnmpPacketV1Trap(Trap, enterprise, agentAddress, genericTrap, specificTrap, timestamp, pdus)
+
+	return x.send(packetOut, false)
+}
+
 //
 // Receiving Traps ie GoSNMP acting as an NMS (Network Management
 // Station).

--- a/trap.go
+++ b/trap.go
@@ -87,10 +87,17 @@ func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, enterprise []int, agentAddress strin
 		return nil, fmt.Errorf("SendV1Trap requires at least 1 pdu")
 	}
 
-	// TODO this function shouldn't exist, just build a struct here.
-	// mkSnmpPacket() has some logic in it (SecurityParameters.Copy(),
-	// hence need for a separate method
-	packetOut := x.mkSnmpPacketV1Trap(Trap, enterprise, agentAddress, genericTrap, specificTrap, timestamp, pdus)
+	packetOut := &SnmpPacket{
+		Version:      x.Version,
+		Community:    x.Community,
+		PDUType:      Trap,
+		Enterprise:   enterprise,
+		AgentAddr:    agentAddress,
+		GenericTrap:  genericTrap,
+		SpecificTrap: specificTrap,
+		Timestamp:    timestamp,
+		Variables:    pdus,
+	}
 
 	return x.send(packetOut, false)
 }

--- a/trap.go
+++ b/trap.go
@@ -60,21 +60,7 @@ func (x *GoSNMP) SendTrap(pdus []SnmpPDU) (result *SnmpPacket, err error) {
 	return x.send(packetOut, false)
 }
 
-/*
-Good practice is to send a struct rather than many parameters (Golang and other languages too). Please change :-)
-
-- it's easier to understand
-- if new parameters need to be added, you can do it without changing the (public) method signature
-
-I would suggest something like:
-func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, niceVariableName NiceStructName) (result *SnmpPacket, err error) {
-  ....
-}
-
-See Connect() in gosnmp.go for an example (though there *GoSNMP
-provides a method on a struct type)
-*/
-func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, enterprise []int, agentAddress string, genericTrap int, specificTrap int, timestamp int) (result *SnmpPacket, err error) {
+func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, snmpV1TrapHeader SNMPV1TrapHeader) (result *SnmpPacket, err error) {
 	switch x.Version {
 	case Version2c, Version3:
 		err = fmt.Errorf("SendV1Trap doesn't support %s", x.Version)
@@ -91,11 +77,11 @@ func (x *GoSNMP) SendV1Trap(pdus []SnmpPDU, enterprise []int, agentAddress strin
 		Version:      x.Version,
 		Community:    x.Community,
 		PDUType:      Trap,
-		Enterprise:   enterprise,
-		AgentAddr:    agentAddress,
-		GenericTrap:  genericTrap,
-		SpecificTrap: specificTrap,
-		Timestamp:    timestamp,
+		Enterprise:   snmpV1TrapHeader.enterprise,
+		AgentAddr:    snmpV1TrapHeader.agentAddress,
+		GenericTrap:  snmpV1TrapHeader.genericTrap,
+		SpecificTrap: snmpV1TrapHeader.specificTrap,
+		Timestamp:    snmpV1TrapHeader.timestamp,
 		Variables:    pdus,
 	}
 


### PR DESCRIPTION
According to: http://www.tcpipguide.com/free/t_SNMPVersion1SNMPv1MessageFormat-3.htm
the SNMP v1 Trap PDU is quite different from standard PDUs, so it has to be created in a bit different way.

I tried to avoid unnecessary changes, and this is the end result of adding support for sending SNMP v1 Traps.