### PR TITLE
Method that returns a channel that can be used to block until the TrapListener is ready

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -42,7 +42,6 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 
 	switch x.Version {
 	case Version2c, Version3:
-		// do nothing
 		pdutype = SNMPv2Trap
 
 		if trap.Variables[0].Type != TimeTicks {


### PR DESCRIPTION
* Added the `Listening()` method on the `TrapListener` to allow the user code to check if the listener is ready to receive requests. Useful for testing `SendTrap` in user scenarios.
* Removed `sync.Cond` and `ready()` because they duplicate the purpose of the introduced `listening` channel; also removed the `listening bool` variable because its `listening=false` value is not used anywhere in tests.
* Replaced the `t.Fatalf` with an error channel to satisfy the `staticcheck` warnings:
  ```
  trap_test.go:163:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
  trap_test.go:224:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)

  ```
* Satisfied the `go vet` and `golint` warnings:
  ```
  trap_test.go:116: arg trapTestGenericTrap for printf verb %s of wrong type: int
  trap_test.go:120: arg trapTestSpecificTrap for printf verb %s of wrong type: int
  trap_test.go:124: arg trapTestTimestamp for printf verb %s of wrong type: int
  trap_test.go:116: arg packet.GenericTrap for printf verb %s of wrong type: int
  trap_test.go:120: arg packet.SpecificTrap for printf verb %s of wrong type: int
  trap_test.go:124: arg packet.Timestamp for printf verb %s of wrong type: int

  trap.go:105:1: comment on exported function NewTrapListener should be of the form "NewTrapListener ..."
  trap.go:184:1: comment on exported method GoSNMP.UnmarshalTrap should be of the form "UnmarshalTrap ..."

  ```
* Corrected a few typos found by `hunspell`.

This PR implements #126.