### PR TITLE
Parse TimeTicks as uint (see RFC 2578 7.1.8).

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -155,7 +155,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (retVal *variable, err err
 		// 0x43
 		x.logPrint("decodeValue: type is TimeTicks")
 		length, cursor := parseLength(data)
-		ret, err := parseInt(data[cursor:length])
+		ret, err := parseUint(data[cursor:length])
 		if err != nil {
 			x.logPrintf("decodeValue: err is %v", err)
 			break
@@ -619,9 +619,9 @@ func parseRawField(data []byte, msg string) (interface{}, int, error) {
 		}
 	case TimeTicks:
 		length, cursor := parseLength(data)
-		ret, err := parseInt(data[cursor:length])
+		ret, err := parseUint(data[cursor:length])
 		if err != nil {
-			return nil, 0, fmt.Errorf("Error in parseInt: %s", err)
+			return nil, 0, fmt.Errorf("Error in parseUint: %s", err)
 		}
 		return ret, length, nil
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -65,7 +65,7 @@ type SnmpTrap struct {
 	AgentAddress string
 	GenericTrap  int
 	SpecificTrap int
-	Timestamp    int
+	Timestamp    uint
 }
 
 // VarBind struct represents an SNMP Varbind.
@@ -882,7 +882,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 		return fmt.Errorf("Error parsing SNMP packet error: %s", err.Error())
 	}
 	cursor += count
-	if Timestamp, ok := rawTimestamp.(int); ok {
+	if Timestamp, ok := rawTimestamp.(uint); ok {
 		response.Timestamp = Timestamp
 		x.logPrintf("Timestamp: %d", Timestamp)
 	}


### PR DESCRIPTION
There is a bug in TimeTicks handling that returns error on correct value >=2^31 (see https://tools.ietf.org/html/rfc2578#section-7.1.8). It only appears on 32-bit systems.

Currently TimeTicks value is returned as int which can't store values >= 2^31 on 32-bit systems. Proposed solution is to change the returned type to uint.

