### PR TITLE
Explicitly handle usmStats report PDUs.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -160,7 +160,6 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			}
 
 		}
-		x.logPrintf("PACKET SENT: %#+v", *packetOut)
 		if x.loggingEnabled && x.Version == Version3 {
 			packetOut.SecurityParameters.Log()
 		}
@@ -173,6 +172,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			break
 		}
 
+		x.logPrintf("SENDING PACKET: %#+v", *packetOut)
 		_, err = x.Conn.Write(outBuf)
 		if err != nil {
 			continue
@@ -183,7 +183,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			return &SnmpPacket{}, nil
 		}
 
-	loop:
+	waitingResponse:
 		for {
 			x.logPrint("WAITING RESPONSE...")
 			// Receive response and try receiving again on any decoding error.
@@ -241,7 +241,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				case ".1.3.6.1.6.3.15.1.1.1.0", ".1.3.6.1.6.3.15.1.1.2.0",
 					".1.3.6.1.6.3.15.1.1.3.0", ".1.3.6.1.6.3.15.1.1.4.0",
 					".1.3.6.1.6.3.15.1.1.5.0", ".1.3.6.1.6.3.15.1.1.6.0":
-					break loop
+					break waitingResponse
 				}
 			}
 

--- a/marshal.go
+++ b/marshal.go
@@ -322,6 +322,17 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 			result, err = x.sendOneRequest(packetOut, wait)
 		}
 	}
+
+	// detect unknown engine id error and retransmit with updated engine id
+	if len(result.Variables) == 1 && result.Variables[0].Name == ".1.3.6.1.6.3.15.1.1.4.0" {
+		x.logPrintf("WARNING detected unknown enginer id ERROR")
+		err = x.updatePktSecurityParameters(packetOut)
+		if err != nil {
+			x.logPrintf("ERROR  updatePktSecurityParameters error: %s", err)
+			return nil, err
+		}
+		result, err = x.sendOneRequest(packetOut, wait)
+	}
 	return result, err
 }
 


### PR DESCRIPTION
Prevents hanging, and eventually timing out, when receiving SNMPv3 usmStats report PDUs.

Fixes #139