### PR TITLE
Data accessed atomically must be 64 bit aligned.

### DIFF
--- a/v3_usm.go
+++ b/v3_usm.go
@@ -45,6 +45,10 @@ const (
 
 // UsmSecurityParameters is an implementation of SnmpV3SecurityParameters for the UserSecurityModel
 type UsmSecurityParameters struct {
+	// localAESSalt must be 64bit aligned to use with atomic operations.
+	localAESSalt uint64
+	localDESSalt uint32
+
 	AuthoritativeEngineID    string
 	AuthoritativeEngineBoots uint32
 	AuthoritativeEngineTime  uint32
@@ -60,9 +64,6 @@ type UsmSecurityParameters struct {
 
 	secretKey  []byte
 	privacyKey []byte
-
-	localDESSalt uint32
-	localAESSalt uint64
 
 	Logger Logger
 }


### PR DESCRIPTION
Fixes part of #142 

There's undocumented test setup that I haven't reverse engineered, but this fixes the nil pointer issue in the 32bit e2e tests anyway.