### PR TITLE
Don't proceed to unmarshal trap after ReadFromUDP errors

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -170,6 +170,7 @@ func (t *TrapListener) Listen(addr string) (err error) {
 					continue
 				}
 				t.Params.logPrintf("TrapListener: error in read %s\n", err)
+				continue
 			}
 
 			msg := buf[:rlen]


### PR DESCRIPTION
A very minor bug fix that didn't occur to me earlier.

If ReadFromUDP errors for whatever reason when Close _hasn't_ been called, we still shouldn't try to unmarshal the data.