### PR TITLE
Add methods for IPv4 & IPv6 only connections

### DIFF
--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -46,8 +46,96 @@ func setupConnection(t *testing.T) {
 	}
 }
 
+func setupConnectionIPv4(t *testing.T) {
+	envTarget := os.Getenv("GOSNMP_TARGET_IPV4")
+	envPort := os.Getenv("GOSNMP_PORT_IPV4")
+
+	if len(envTarget) <= 0 {
+		t.Skip("skipping: environment variable not set: GOSNMP_TARGET_IPV4")
+	}
+	Default.Target = envTarget
+
+	if len(envPort) <= 0 {
+		t.Skip("skipping: environment variable not set: GOSNMP_PORT_IPV4")
+	}
+	port, _ := strconv.ParseUint(envPort, 10, 16)
+	Default.Port = uint16(port)
+
+	err := Default.ConnectIPv4()
+	if err != nil {
+		if len(envTarget) > 0 {
+			t.Fatalf("Connection failed. Is snmpd reachable on %s:%s?\n(err: %v)",
+				envTarget, envPort, err)
+		}
+	}
+}
+
+func setupConnectionIPv6(t *testing.T) {
+	envTarget := os.Getenv("GOSNMP_TARGET_IPV6")
+	envPort := os.Getenv("GOSNMP_PORT_IPV6")
+
+	if len(envTarget) <= 0 {
+		t.Skip("skipping: environment variable not set: GOSNMP_TARGET_IPV6")
+	}
+	Default.Target = envTarget
+
+	if len(envPort) <= 0 {
+		t.Skip("skipping: environment variable not set: GOSNMP_PORT_IPV6")
+	}
+	port, _ := strconv.ParseUint(envPort, 10, 16)
+	Default.Port = uint16(port)
+
+	err := Default.ConnectIPv6()
+	if err != nil {
+		if len(envTarget) > 0 {
+			t.Fatalf("Connection failed. Is snmpd reachable on %s:%s?\n(err: %v)",
+				envTarget, envPort, err)
+		}
+	}
+}
+
 func TestGenericBasicGet(t *testing.T) {
 	setupConnection(t)
+	defer Default.Conn.Close()
+
+	result, err := Default.Get([]string{".1.3.6.1.2.1.1.1.0"}) // SNMP MIB-2 sysDescr
+	if err != nil {
+		t.Fatalf("Get() failed with error => %v", err)
+	}
+	if len(result.Variables) != 1 {
+		t.Fatalf("Expected result of size 1")
+	}
+	if result.Variables[0].Type != OctetString {
+		t.Fatalf("Expected sysDescr to be OctetString")
+	}
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
+		t.Fatalf("Got a zero length sysDescr")
+	}
+}
+
+func TestGenericBasicGetIPv4Only(t *testing.T) {
+	setupConnectionIPv4(t)
+	defer Default.Conn.Close()
+
+	result, err := Default.Get([]string{".1.3.6.1.2.1.1.1.0"}) // SNMP MIB-2 sysDescr
+	if err != nil {
+		t.Fatalf("Get() failed with error => %v", err)
+	}
+	if len(result.Variables) != 1 {
+		t.Fatalf("Expected result of size 1")
+	}
+	if result.Variables[0].Type != OctetString {
+		t.Fatalf("Expected sysDescr to be OctetString")
+	}
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
+		t.Fatalf("Got a zero length sysDescr")
+	}
+}
+
+func TestGenericBasicGetIPv6Only(t *testing.T) {
+	setupConnectionIPv6(t)
 	defer Default.Conn.Close()
 
 	result, err := Default.Get([]string{".1.3.6.1.2.1.1.1.0"}) // SNMP MIB-2 sysDescr

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -199,6 +199,18 @@ const (
 // For historical reasons (ie this is part of the public API), the method won't
 // be renamed.
 func (x *GoSNMP) Connect() error {
+	return x.connect("udp")
+}
+
+func (x *GoSNMP) ConnectIPv4() error {
+	return x.connect("udp4")
+}
+
+func (x *GoSNMP) ConnectIPv6() error {
+	return x.connect("udp6")
+}
+
+func (x *GoSNMP) connect(network string) error {
 	var err error
 	err = x.validateParameters()
 	if err != nil {


### PR DESCRIPTION
In Connect(), DNS resolution for the network type passed to net.DialTimeout will resolve both IPv4 and IPv6 addresses, and choose one to use.  This adds ConnectIPv4() & ConnectIPv6() to only use IPv4 or IPv6, respectively.  The behavior of Connect() is unchanged.

A basic get test has also been added to test each method.