### PR TITLE
Expose SnmpEncodePacket/SnmpDecodePacket

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -211,71 +211,6 @@ func (x *GoSNMP) ConnectIPv6() error {
 	return x.connect("udp6")
 }
 
-func (x *GoSNMP) SnmpEncodePacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) ([]byte, error) {
-	var err error = nil
-
-	pkt := x.mkSnmpPacket(pdutype, pdus, nonRepeaters, maxRepetitions)
-
-	// Request ID is an atomic counter (started at a random value)
-	reqID := atomic.AddUint32(&(x.requestID), 1) // TODO: fix overflows
-	pkt.RequestID = reqID
-
-	if x.Version == Version3 {
-		msgID := atomic.AddUint32(&(x.msgID), 1) // TODO: fix overflows
-		pkt.MsgID = msgID
-
-		err = x.initPacket(pkt)
-		if err != nil {
-			return []byte{}, err
-		}
-	}
-
-	var out []byte
-	out, err = pkt.marshalMsg()
-	if err != nil {
-		return []byte{}, err
-	}
-
-	return out, nil
-}
-
-func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
-	var err error = nil
-
-	result := new(SnmpPacket)
-	result.Logger = x.Logger
-
-	var cursor int
-	cursor, err = x.unmarshalHeader(resp, result)
-	if err != nil {
-		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
-		return result, err
-	}
-
-	if x.Version == Version3 {
-		err = x.testAuthentication(resp, result)
-		if err != nil {
-			return result, err
-		}
-		resp, cursor, err = x.decryptPacket(resp, cursor, result)
-		if err != nil {
-			return result, err
-		}
-	}
-
-	err = x.unmarshalPayload(resp, cursor, result)
-	if err != nil {
-		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
-		return result, err
-	}
-
-	if result == nil || len(result.Variables) < 1 {
-		err = fmt.Errorf("Unable to decode packet: no variables")
-		return result, err
-	}
-	return result, nil
-}
-
 func (x *GoSNMP) connect(network string) error {
 	var err error
 	err = x.validateParameters()
@@ -423,6 +358,77 @@ func (x *GoSNMP) GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint8
 	// Marshal and send the packet
 	packetOut := x.mkSnmpPacket(GetBulkRequest, pdus, nonRepeaters, maxRepetitions)
 	return x.send(packetOut, true)
+}
+
+// SnmpEncodePacket exposes SNMP packet generation to external callers.
+// This is useful for generating traffic for use over separate transport
+// stacks and creating traffic samples for test purposes.
+func (x *GoSNMP) SnmpEncodePacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) ([]byte, error) {
+	var err error = nil
+
+	pkt := x.mkSnmpPacket(pdutype, pdus, nonRepeaters, maxRepetitions)
+
+	// Request ID is an atomic counter (started at a random value)
+	reqID := atomic.AddUint32(&(x.requestID), 1) // TODO: fix overflows
+	pkt.RequestID = reqID
+
+	if x.Version == Version3 {
+		msgID := atomic.AddUint32(&(x.msgID), 1) // TODO: fix overflows
+		pkt.MsgID = msgID
+
+		err = x.initPacket(pkt)
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+
+	var out []byte
+	out, err = pkt.marshalMsg()
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return out, nil
+}
+
+// SnmpEncodePacket exposes SNMP packet parsing to external callers.
+// This is useful for processing traffic from other sources and
+// building test harnesses.
+func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
+	var err error = nil
+
+	result := new(SnmpPacket)
+	result.Logger = x.Logger
+
+	var cursor int
+	cursor, err = x.unmarshalHeader(resp, result)
+	if err != nil {
+		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
+		return result, err
+	}
+
+	if x.Version == Version3 {
+		err = x.testAuthentication(resp, result)
+		if err != nil {
+			return result, err
+		}
+		resp, cursor, err = x.decryptPacket(resp, cursor, result)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	err = x.unmarshalPayload(resp, cursor, result)
+	if err != nil {
+		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
+		return result, err
+	}
+
+	if result == nil || len(result.Variables) < 1 {
+		err = fmt.Errorf("Unable to decode packet: no variables")
+		return result, err
+	}
+	return result, nil
 }
 
 //

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -248,7 +248,6 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 	var cursor int
 	cursor, err = x.unmarshalHeader(resp, result)
 	if err != nil {
-		x.logPrintf("ERROR on unmarshall header: %s", err)
 		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
 		return result, err
 	}
@@ -256,26 +255,22 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 	if x.Version == Version3 {
 		err = x.testAuthentication(resp, result)
 		if err != nil {
-			x.logPrintf("ERROR on Test Authentication on v3: %s", err)
 			return result, err
 		}
 		resp, cursor, err = x.decryptPacket(resp, cursor, result)
 		if err != nil {
-			x.logPrintf("ERROR decrypting on v3: %s", err)
 			return result, err
 		}
 	}
 
 	err = x.unmarshalPayload(resp, cursor, result)
 	if err != nil {
-		x.logPrintf("ERROR on UnmarshalPayload on v3: %s", err)
 		err = fmt.Errorf("Unable to decode packet: %s", err.Error())
 		return result, err
 	}
 
 	if result == nil || len(result.Variables) < 1 {
-		x.logPrintf("ERROR on UnmarshalPayload on v3: %s", err)
-		err = fmt.Errorf("Unable to decode packet: nil")
+		err = fmt.Errorf("Unable to decode packet: no variables")
 		return result, err
 	}
 	return result, nil

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -391,7 +391,7 @@ func (x *GoSNMP) SnmpEncodePacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters 
 	return out, nil
 }
 
-// SnmpEncodePacket exposes SNMP packet parsing to external callers.
+// SnmpDecodePacket exposes SNMP packet parsing to external callers.
 // This is useful for processing traffic from other sources and
 // building test harnesses.
 func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {


### PR DESCRIPTION
This PR exposes two public functions that allow packet encoding and decoding outside of the transport calls. This is useful when you want to play with SNMP packets without sending them through gosnmp. The atomic AddUint32s should probable be converted to AddUint64 and a mask, but that would be better done in a second PR so that it is consistent across the project.