### PR TITLE
Support SNMPv3 Encode/Decode

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -43,6 +43,7 @@ type SnmpPacket struct {
 	PDUType            PDUType
 	MsgID              uint32
 	RequestID          uint32
+	MsgMaxSize         uint32
 	Error              SNMPError
 	ErrorIndex         uint8
 	NonRepeaters       uint8

--- a/v3.go
+++ b/v3.go
@@ -312,13 +312,16 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 		response.MsgID = uint32(MsgID)
 		x.logPrintf("Parsed message ID %d", MsgID)
 	}
-	// discard msg max size
-	_, count, err = parseRawField(packet[cursor:], "maxMsgSize")
+
+	rawMsgMaxSize, count, err := parseRawField(packet[cursor:], "msgMaxSize")
 	if err != nil {
-		return 0, fmt.Errorf("Error parsing SNMPV3 maxMsgSize: %s", err.Error())
+		return 0, fmt.Errorf("Error parsing SNMPV3 msgMaxSize: %s", err.Error())
 	}
 	cursor += count
-	// discard msg max size
+	if MsgMaxSize, ok := rawMsgMaxSize.(int); ok {
+		response.MsgMaxSize = uint32(MsgMaxSize)
+		x.logPrintf("Parsed message max size %d", MsgMaxSize)
+	}
 
 	rawMsgFlags, count, err := parseRawField(packet[cursor:], "msgFlags")
 	if err != nil {
@@ -346,19 +349,20 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	_, cursorTmp = parseLength(packet[cursor:])
 	cursor += cursorTmp
 
-	if response.SecurityParameters == nil {
-		return 0, fmt.Errorf("Unable to parse V3 packet - unknown security model")
+	if response.SecurityParameters != nil {
+		cursor, err = response.SecurityParameters.unmarshal(response.MsgFlags, packet, cursor)
+		if err != nil {
+			return 0, err
+		}
 	}
 
-	cursor, err = response.SecurityParameters.unmarshal(response.MsgFlags, packet, cursor)
-	if err != nil {
-		return 0, err
-	}
 	return cursor, nil
 }
 
 func (x *GoSNMP) decryptPacket(packet []byte, cursor int, response *SnmpPacket) ([]byte, int, error) {
 	var err error
+	var decrypted = false
+
 	switch PDUType(packet[cursor]) {
 	case OctetString:
 		// pdu is encrypted
@@ -366,13 +370,16 @@ func (x *GoSNMP) decryptPacket(packet []byte, cursor int, response *SnmpPacket) 
 		if err != nil {
 			return nil, 0, err
 		}
+		decrypted = true
 		fallthrough
 	case Sequence:
-		// pdu is plaintext
+		// pdu is plaintext or has been decrypted
 		tlength, cursorTmp := parseLength(packet[cursor:])
-		// truncate padding that may have been included with
-		// the encrypted PDU
-		packet = packet[:cursor+tlength]
+		if decrypted {
+			// truncate padding that might have been included with
+			// the encrypted PDU
+			packet = packet[:cursor+tlength]
+		}
 		cursor += cursorTmp
 		rawContextEngineID, count, err := parseRawField(packet[cursor:], "contextEngineID")
 		if err != nil {


### PR DESCRIPTION
This changeset enables better support for SNMPv3 in `SnmpEncodePacket()` and `SnmpDecodePacket()` by supporting `SecurityParameters`, exposing `SetMsgID`/`SetRequestID`/`MsgMaxSize`, and calling the `validateParameters()` function.