### PR TITLE
Fix timeout and retry

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -57,6 +57,9 @@ type GoSNMP struct {
 	// Set the number of retries to attempt within timeout.
 	Retries int
 
+	// Double timeout in each retry
+	ExponentialTimeout bool
+
 	// Logger is the GoSNMP.Logger to use for debugging. If nil, debugging
 	// output will be discarded (/dev/null). For verbose logging to stdout:
 	// x.Logger = log.New(os.Stdout, "", 0)
@@ -106,12 +109,13 @@ type GoSNMP struct {
 
 // Default connection settings
 var Default = &GoSNMP{
-	Port:      161,
-	Community: "public",
-	Version:   Version2c,
-	Timeout:   time.Duration(2) * time.Second,
-	Retries:   3,
-	MaxOids:   MaxOids,
+	Port:               161,
+	Community:          "public",
+	Version:            Version2c,
+	Timeout:            time.Duration(2) * time.Second,
+	Retries:            3,
+	ExponentialTimeout: true,
+	MaxOids:            MaxOids,
 }
 
 // SnmpPDU will be used when doing SNMP Set's

--- a/interface.go
+++ b/interface.go
@@ -125,6 +125,12 @@ type Handler interface {
 	// SetRetries sets the Retries
 	SetRetries(retries int)
 
+	// GetExponentialTimeout gets the ExponentialTimeout
+	GetExponentialTimeout() bool
+
+	// SetExponentialTimeout sets the ExponentialTimeout
+	SetExponentialTimeout(value bool)
+
 	// Logger gets the Logger
 	Logger() Logger
 
@@ -246,6 +252,14 @@ func (x *snmpHandler) Retries() int {
 
 func (x *snmpHandler) SetRetries(retries int) {
 	x.GoSNMP.Retries = retries
+}
+
+func (x *snmpHandler) GetExponentialTimeout() bool {
+	return x.GoSNMP.ExponentialTimeout
+}
+
+func (x *snmpHandler) SetExponentialTimeout(value bool) {
+	x.GoSNMP.ExponentialTimeout = value
 }
 
 func (x *snmpHandler) Logger() Logger {

--- a/marshal.go
+++ b/marshal.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -133,7 +134,9 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				timeout *= 2
 			}
 			if retries > x.Retries {
-				err = fmt.Errorf("Request timeout (after %d retries)", retries-1)
+				if strings.Contains(err.Error(), "timeout") {
+					err = fmt.Errorf("Request timeout (after %d retries)", retries-1)
+				}
 				break
 			}
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -133,7 +133,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				timeout *= 2
 			}
 			if retries > x.Retries {
-				// Report last error
+				err = fmt.Errorf("Request timeout (after %d retries)", retries-1)
 				break
 			}
 		}


### PR DESCRIPTION
Fix exponential timeout bug and make it optional for user to choose between exponential and linear timeout as described here:
### https://www.webnms.com/snmp/help/snmpapi/snmpv3/v1/timeout.html