### PR TITLE
Removed bit-lopping

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -364,6 +364,15 @@ func marshalInt32(value int) (rs []byte, err error) {
 	rs = make([]byte, 4)
 	if 0 <= value && value <= 2147483647 {
 		binary.BigEndian.PutUint32(rs, uint32(value))
+		if value <= 0x80 {
+			return rs[3:], nil
+		}
+		if value <= 0x8000 {
+			return rs[2:], nil
+		}
+		if value <= 0x800000 {
+			return rs[1:], nil
+		}
 		return rs, nil
 	}
 	if -2147483648 <= value && value < 0 {
@@ -383,13 +392,13 @@ func marshalUint32(v interface{}) ([]byte, error) {
 	source := v.(uint32)
 	binary.BigEndian.PutUint32(bs, source) // will panic on failure
 	// truncate leading zeros. Cleaner technique?
-	if source <= 0xff {
+	if source <= 0x80 {
 		return bs[3:], nil
 	}
-	if source <= 0xffff {
+	if source <= 0x8000 {
 		return bs[2:], nil
 	}
-	if source <= 0xffffff {
+	if source <= 0x800000 {
 		return bs[1:], nil
 	}
 	return bs, nil

--- a/helper.go
+++ b/helper.go
@@ -364,13 +364,6 @@ func marshalInt32(value int) (rs []byte, err error) {
 	rs = make([]byte, 4)
 	if 0 <= value && value <= 2147483647 {
 		binary.BigEndian.PutUint32(rs, uint32(value))
-		i := 0
-		for ; i < 3; i++ {
-			if rs[i] != 0 {
-				break
-			}
-		}
-		rs = rs[i:]
 		return rs, nil
 	}
 	if -2147483648 <= value && value < 0 {

--- a/helper_test.go
+++ b/helper_test.go
@@ -47,7 +47,7 @@ type testsMarshalUint32T struct {
 
 var testsMarshalUint32 = []testsMarshalUint32T{
 	{0, []byte{0x00}},
-	{2, []byte{0x02}},                          // 2
+	{2, []byte{0x02}},  // 2
 	{257, []byte{0x01, 0x01}},                  // FF + 2
 	{65537, []byte{0x01, 0x00, 0x01}},          // FFFF + 2
 	{16777217, []byte{0x01, 0x00, 0x00, 0x01}}, // FFFFFF + 2


### PR DESCRIPTION
A problem existed where integers between 128 and 255 inclusive were being improperly encoded. 

The cause was the removed code, which was lopping off zeroed bytes. Those bytes were necessary to recognize as full int32 by receiving devices. Without them, the single byte was treated as int8 - below 128 and values are same as int32. Above 255 and you're into int16 which is the same.

I suspect another issue would have happened at the boundaries around signed int16s.