### PR TITLE
 negotiateInitalSecurityParameters use local SecurityParameters & remote SecurityParameters  v3.go

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -85,7 +85,7 @@ func (x *GoSNMP) testAuthentication(packet []byte, result *SnmpPacket) error {
 		return fmt.Errorf("testAuthentication called with non Version3 connection")
 	}
 
-	if x.MsgFlags&AuthNoPriv > 0 {
+	if x.MsgFlags&AuthNoPriv > 0 && result.MsgFlags&AuthNoPriv > 0  {
 		authentic, err := x.SecurityParameters.isAuthentic(packet, result)
 		if err != nil {
 			return err


### PR DESCRIPTION
maybe a bug.
#171
#172