### PR TITLE
Add support for Walk and Get over TCP

### DIFF
--- a/examples/walktcpexample.go
+++ b/examples/walktcpexample.go
@@ -1,0 +1,81 @@
+// Copyright 2012-2014 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// This program demonstrates BulkWalk.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/soniah/gosnmp"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("Usage:\n")
+		fmt.Printf("   %s [-community=<community>] host [oid]\n", filepath.Base(os.Args[0]))
+		fmt.Printf("     host      - the host to walk/scan\n")
+		fmt.Printf("     oid       - the MIB/Oid defining a subtree of values\n\n")
+		flag.PrintDefaults()
+	}
+
+	var community string
+	flag.StringVar(&community, "community", "public", "the community string for device")
+
+	flag.Parse()
+
+	if len(flag.Args()) < 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	target := flag.Args()[0]
+	var oid string
+	if len(flag.Args()) > 1 {
+		oid = flag.Args()[1]
+	}
+
+	gosnmp.Default.Target = target
+	gosnmp.Default.Transport = "tcp"
+	gosnmp.Default.Community = community
+	gosnmp.Default.Timeout = time.Duration(10 * time.Second) // Timeout better suited to walking
+	gosnmp.Default.Logger = log.New(os.Stdout, "", 0)
+	err := gosnmp.Default.Connect()
+	if err != nil {
+		fmt.Printf("Connect err: %v\n", err)
+		os.Exit(1)
+	}
+	defer gosnmp.Default.Conn.Close()
+
+	err = gosnmp.Default.BulkWalk(oid, printValue)
+	if err != nil {
+		fmt.Printf("Walk Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// This may lead to the remote server closing the TCP connection
+	time.Sleep(15 * time.Second)
+	err = gosnmp.Default.BulkWalk(oid, printValue)
+	if err != nil {
+		fmt.Printf("Walk Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printValue(pdu gosnmp.SnmpPDU) error {
+	fmt.Printf("%s = ", pdu.Name)
+
+	switch pdu.Type {
+	case gosnmp.OctetString:
+		b := pdu.Value.([]byte)
+		fmt.Printf("STRING: %s\n", string(b))
+	default:
+		fmt.Printf("TYPE %d: %d\n", pdu.Type, gosnmp.ToBigInt(pdu.Value))
+	}
+	return nil
+}


### PR DESCRIPTION
RFC 3430 specifies the transport of SNMP over TCP. It can be used to
support more efficient bulk transfers. This is supported in net-snmp and
the snmpd from OpenBSD for example.

This commit adds the field Transport to the GoSNMP struct that allows
the selection of UDP or TCP as transport layer. Connect() uses the
specified method to query the server. The interface of the library
remains the same.

As the connection can be closed at any time by the server, we need to
handle an EOF from the connection gracefully. This change also adds an
example to walk using TCP. It was tested against the snmpd from OpenBSD.