### PR TITLE
v3: avoid crash on missing SecurityParameters

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -56,6 +56,9 @@ func (x *GoSNMP) validateParametersV3() error {
 	if x.SecurityModel != UserSecurityModel {
 		return fmt.Errorf("The SNMPV3 User Security Model is the only SNMPV3 security model currently implemented")
 	}
+	if x.SecurityParameters == nil {
+		return fmt.Errorf("SNMPV3 SecurityParameters must be set")
+	}
 
 	return x.SecurityParameters.validate(x.MsgFlags)
 }


### PR DESCRIPTION
Gives a meaningful error message when user (me) is misusing the api :-)

Consider the following

```go
package snmptest

import (
	"fmt"
	"log"
	"testing"
	"time"

	"github.com/soniah/gosnmp"
)

func TestSNMP(t *testing.T) {

	params := &gosnmp.GoSNMP{
		Target:    "172.16.72.143",
		Port:      161,
		Version:   gosnmp.Version3,
		Community: "public",
		Timeout:   time.Duration(1) * time.Second,
		// v3 - noauth:
		SecurityModel: gosnmp.UserSecurityModel,
		MsgFlags:      gosnmp.NoAuthNoPriv,
		/*
			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "authOnlyUser",
				AuthenticationProtocol:   gosnmp.SHA,
				AuthenticationPassphrase: "password",
			},*/
	}

	err := params.Connect()
	if err != nil {
		log.Fatalf("SNMP Connect() err: %v", err)
	}
	defer params.Conn.Close()

	...
}
```


Without this patch, the above code explodes because SecurityParameters is missing:

```
--- FAIL: TestSNMP (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x42bdac7]

goroutine 4 [running]:
testing.tRunner.func1(0xc000148100)
	/usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:830 +0x392
panic(0x4328c40, 0x4639520)
	/usr/local/Cellar/go/1.12.5/libexec/src/runtime/panic.go:522 +0x1b5
github.com/soniah/gosnmp.(*GoSNMP).validateParametersV3(0xc000148200, 0xc0000de370, 0x4479702)
	/Users/m/dev/go/src/github.com/soniah/gosnmp/v3.go:60 +0xd7
github.com/soniah/gosnmp.(*GoSNMP).validateParameters(0xc000148200, 0xe8, 0xf8)
	/Users/m/dev/go/src/github.com/soniah/gosnmp/gosnmp.go:296 +0xa8
github.com/soniah/gosnmp.(*GoSNMP).connect(0xc000148200, 0x0, 0x0, 0xc000000539, 0x400e259)
	/Users/m/dev/go/src/github.com/soniah/gosnmp/gosnmp.go:241 +0x40
github.com/soniah/gosnmp.(*GoSNMP).Connect(...)
	/Users/m/dev/go/src/github.com/soniah/gosnmp/gosnmp.go:221
github.com/martinlindhe/snmptest/snmptest.TestSNMP(0xc000148100)
	/Users/m/dev/go/src/github.com/martinlindhe/snmptest/snmp_test.go:50 +0xb9
testing.tRunner(0xc000148100, 0x43a36f0)
	/usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:916 +0x35a
exit status 2
```
