### PR TITLE
Add support for contexts

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -9,6 +9,7 @@
 package gosnmp
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -54,10 +55,13 @@ type GoSNMP struct {
 	// Version is an SNMP Version
 	Version SnmpVersion
 
-	// Timeout is the timeout for the SNMP Query
+	// Context allows for overall deadlines and cancellation
+	Context context.Context
+
+	// Timeout is the timeout for one SNMP request/response
 	Timeout time.Duration
 
-	// Set the number of retries to attempt within timeout.
+	// Set the number of retries to attempt within timeout
 	Retries int
 
 	// Double timeout in each retry
@@ -268,7 +272,8 @@ func (x *GoSNMP) connect(networkSuffix string) error {
 func (x *GoSNMP) netConnect() error {
 	var err error
 	addr := net.JoinHostPort(x.Target, strconv.Itoa(int(x.Port)))
-	x.Conn, err = net.DialTimeout(x.Transport, addr, x.Timeout)
+	dialer := net.Dialer{Timeout: x.Timeout}
+	x.Conn, err = dialer.DialContext(x.Context, x.Transport, addr)
 	return err
 }
 
@@ -300,6 +305,10 @@ func (x *GoSNMP) validateParameters() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if x.Context == nil {
+		x.Context = context.Background()
 	}
 
 	return nil


### PR DESCRIPTION
This allows for walks as a whole to have a deadline, rather
than just individual request/responses.

Fixes #97