### PR TITLE
SnmpDecodePacket: Allow to decode snmp request packets

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -480,7 +480,7 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 		return result, err
 	}
 
-	if result == nil || len(result.Variables) < 1 {
+	if result == nil {
 		err = fmt.Errorf("Unable to decode packet: no variables")
 		return result, err
 	}

--- a/helper.go
+++ b/helper.go
@@ -349,6 +349,15 @@ func marshalInt32(value int) (rs []byte, err error) {
 	return nil, fmt.Errorf("unable to marshal %d", value)
 }
 
+func marshalUint64(v interface{}) ([]byte, error) {
+	bs := make([]byte, 8)
+	source := v.(uint64)
+	binary.BigEndian.PutUint64(bs, source) // will panic on failure
+	// truncate leading zeros. Cleaner technique?
+	return bytes.TrimLeft(bs, "\x00"), nil
+	//return bs, nil
+}
+
 // Counter32, Gauge32, TimeTicks, Unsigned32
 func marshalUint32(v interface{}) ([]byte, error) {
 	bs := make([]byte, 4)
@@ -366,6 +375,20 @@ func marshalUint32(v interface{}) ([]byte, error) {
 	}
 	return bs, nil
 
+}
+
+func marshalFloat32(v interface{}) ([]byte, error) {
+	//func Float64bits(f float64) uint64
+	source := v.(float32)
+	i32 := math.Float32bits(source)
+	return marshalUint32(i32)
+}
+
+func marshalFloat64(v interface{}) ([]byte, error) {
+	//func Float64bits(f float64) uint64
+	source := v.(float64)
+	i64 := math.Float64bits(source)
+	return marshalUint64(i64)
 }
 
 // marshalLength builds a byte representation of length

--- a/helper.go
+++ b/helper.go
@@ -190,7 +190,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (retVal *variable, err err
 			return retVal, fmt.Errorf("not enough data for TimeTicks %x (data %d length %d)", data, len(data), length)
 		}
 
-		ret, err := parseUint(data[cursor:length])
+		ret, err := parseUint32(data[cursor:length])
 		if err != nil {
 			x.logPrintf("decodeValue: err is %v", err)
 			break
@@ -365,6 +365,7 @@ func marshalUint32(v interface{}) ([]byte, error) {
 		return bs[1:], nil
 	}
 	return bs, nil
+
 }
 
 // marshalLength builds a byte representation of length
@@ -654,6 +655,16 @@ func parseUint64(bytes []byte) (ret uint64, err error) {
 		ret |= uint64(bytes[bytesRead])
 	}
 	return
+}
+
+// parseUint32 treats the given bytes as a big-endian, signed integer and returns
+// the result.
+func parseUint32(bytes []byte) (uint32, error) {
+	ret, err := parseUint(bytes)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(ret), nil
 }
 
 // parseUint treats the given bytes as a big-endian, signed integer and returns

--- a/marshal.go
+++ b/marshal.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"reflect"
 	"strings"
 	"sync/atomic"
 )
@@ -620,7 +621,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 			intBytes, err = marshalUint32(value)
 			pdu.Check(err)
 		default:
-			return nil, fmt.Errorf("Unable to marshal pdu.Type %v; unknown pdu.Value %v", pdu.Type, pdu.Value)
+			return nil, fmt.Errorf("Unable to marshal pdu.Type %v; unknown pdu.Value %v[type=%v]", pdu.Type, pdu.Value, reflect.TypeOf(pdu.Value))
 		}
 		tmpBuf.Write([]byte{byte(pdu.Type), byte(len(intBytes))})
 		tmpBuf.Write(intBytes)
@@ -796,7 +797,7 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 	requestType := PDUType(packet[cursor])
 	switch requestType {
 	// known, supported types
-	case GetResponse, GetNextRequest, GetBulkRequest, Report, SNMPv2Trap:
+	case GetResponse, GetNextRequest, GetBulkRequest, Report, SNMPv2Trap, GetRequest, SetRequest, InformRequest:
 		response.PDUType = requestType
 		err = x.unmarshalResponse(packet[cursor:], response)
 		if err != nil {

--- a/marshal.go
+++ b/marshal.go
@@ -644,7 +644,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 		pduBuf.WriteByte(byte(len(oid) + len(intBytes) + 4))
 		pduBuf.Write(tmpBuf.Bytes())
 
-	case OctetString:
+	case OctetString, BitString:
 		//Oid
 		tmpBuf.Write([]byte{byte(ObjectIdentifier), byte(len(oid))})
 		tmpBuf.Write(oid)
@@ -665,7 +665,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		tmpBuf.WriteByte(byte(OctetString))
+		tmpBuf.WriteByte(byte(pdu.Type))
 		tmpBuf.Write(length)
 		tmpBuf.Write(octetStringBytes)
 

--- a/marshal.go
+++ b/marshal.go
@@ -506,10 +506,10 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		}
 
 		// error
-		buf.Write([]byte{2, 1, 0})
+		buf.Write([]byte{2, 1, byte(packet.Error)})
 
 		// error index
-		buf.Write([]byte{2, 1, 0})
+		buf.Write([]byte{2, 1, byte(packet.ErrorIndex)})
 
 	}
 

--- a/marshal.go
+++ b/marshal.go
@@ -752,7 +752,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 		pduBuf.WriteByte(byte(Sequence))
 		pduBuf.Write(length)
 		pduBuf.Write(tmpBytes)
-	case NoSuchInstance, NoSuchObject:
+	case NoSuchInstance, NoSuchObject, EndOfMibView:
 		tmpBuf.Write([]byte{byte(ObjectIdentifier), byte(len(oid))})
 		tmpBuf.Write(oid)
 		tmpBuf.WriteByte(byte(pdu.Type))

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -339,6 +339,22 @@ func TestEnmarshalMsg(t *testing.T) {
 			t.Errorf("#%s: marshal() err returned: %v", test.funcName, err)
 		}
 		checkByteEquality(t, test, testBytes, 0, test.finish)
+		t.Run(fmt.Sprintf("TestEnmarshalMsgUnmarshal/PDU[%v]/RequestID[%v]", test.requestType, test.requestid), func(t *testing.T) {
+			vhandle := GoSNMP{}
+			result, err := vhandle.SnmpDecodePacket(testBytes)
+			if err != nil {
+				t.Errorf("#%s: SnmpDecodePacket() err returned: %v", test.funcName, err)
+			}
+			newResultTestBytes, err := result.marshalMsg()
+			if err != nil {
+				t.Errorf("#%s: marshal() err returned: %v", test.funcName, err)
+			}
+			if len(newResultTestBytes) == 0 {
+				t.Errorf("#%s: marshal() length of result is 0 : %v", test.funcName, (newResultTestBytes))
+				return
+			}
+			checkByteEquality(t, test, newResultTestBytes, 0, test.finish)
+		})
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -13,7 +13,10 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"reflect"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -341,6 +344,7 @@ func TestEnmarshalMsg(t *testing.T) {
 		checkByteEquality(t, test, testBytes, 0, test.finish)
 		t.Run(fmt.Sprintf("TestEnmarshalMsgUnmarshal/PDU[%v]/RequestID[%v]", test.requestType, test.requestid), func(t *testing.T) {
 			vhandle := GoSNMP{}
+			vhandle.Logger = Default.Logger
 			result, err := vhandle.SnmpDecodePacket(testBytes)
 			if err != nil {
 				t.Errorf("#%s: SnmpDecodePacket() err returned: %v", test.funcName, err)
@@ -677,105 +681,121 @@ var testsUnmarshal = []struct {
 			},
 		},
 	},
+	{snmpv3HelloRequest,
+		&SnmpPacket{
+			Version:    Version3,
+			PDUType:    GetRequest,
+			MsgID:      91040642,
+			RequestID:  1157240545,
+			Error:      0,
+			ErrorIndex: 0,
+			Variables:  []SnmpPDU{},
+		},
+	},
+	{snmpv3HelloResponse,
+		&SnmpPacket{
+			Version:    Version3,
+			PDUType:    Report,
+			MsgID:      91040642,
+			RequestID:  1157240545,
+			Error:      0,
+			ErrorIndex: 0,
+			Variables: []SnmpPDU{
+				{
+					Name:  ".1.3.6.1.6.3.15.1.1.4.0",
+					Type:  Counter32,
+					Value: 21,
+				},
+			},
+		},
+	},
 }
 
 func TestUnmarshal(t *testing.T) {
 	Default.Logger = log.New(ioutil.Discard, "", 0)
 
-SANITY:
 	for i, test := range testsUnmarshal {
-		var err error
-		var res = new(SnmpPacket)
-		var cursor int
-
-		var buf = test.in()
-		cursor, err = Default.unmarshalHeader(buf, res)
-		if err != nil {
-			t.Errorf("#%d, UnmarshalHeader returned err: %v", i, err)
-			continue SANITY
-		}
-		if res.Version == Version3 {
-			buf, cursor, err = Default.decryptPacket(buf, cursor, res)
+		funcName := runtime.FuncForPC(reflect.ValueOf(test.in).Pointer()).Name()
+		splitedFuncName := strings.Split(funcName, ".")
+		funcName = splitedFuncName[len(splitedFuncName)-1]
+		t.Run(fmt.Sprintf("%v-%v", i, funcName), func(t *testing.T) {
+			vhandle := GoSNMP{}
+			vhandle.Logger = Default.Logger
+			testBytes := test.in()
+			res, err := vhandle.SnmpDecodePacket(testBytes)
 			if err != nil {
-				t.Errorf("#%d, decryptPacket returned err: %v", i, err)
-			}
-		}
-		err = Default.unmarshalPayload(test.in(), cursor, res)
-		if err != nil {
-			t.Errorf("#%d, UnmarshalPayload returned err: %v", i, err)
-		}
-		if res == nil {
-			t.Errorf("#%d, Unmarshal returned nil", i)
-			continue SANITY
-		}
-
-		// test "header" fields
-		if res.Version != test.out.Version {
-			t.Errorf("#%d Version result: %v, test: %v", i, res.Version, test.out.Version)
-		}
-		if res.Community != test.out.Community {
-			t.Errorf("#%d Community result: %v, test: %v", i, res.Community, test.out.Community)
-		}
-		if res.PDUType != test.out.PDUType {
-			t.Errorf("#%d PDUType result: %v, test: %v", i, res.PDUType, test.out.PDUType)
-		}
-		if res.RequestID != test.out.RequestID {
-			t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
-		}
-		if res.Error != test.out.Error {
-			t.Errorf("#%d Error result: %v, test: %v", i, res.Error, test.out.Error)
-		}
-		if res.ErrorIndex != test.out.ErrorIndex {
-			t.Errorf("#%d ErrorIndex result: %v, test: %v", i, res.ErrorIndex, test.out.ErrorIndex)
-		}
-
-		// test varbind values
-		for n, vb := range test.out.Variables {
-			if len(res.Variables) < n {
-				t.Errorf("#%d:%d ran out of varbind results", i, n)
-				continue SANITY
-			}
-			vbr := res.Variables[n]
-
-			if vbr.Name != vb.Name {
-				t.Errorf("#%d:%d Name result: %v, test: %v", i, n, vbr.Name, vb.Name)
-			}
-			if vbr.Type != vb.Type {
-				t.Errorf("#%d:%d Type result: %v, test: %v", i, n, vbr.Type, vb.Type)
+				t.Errorf("#%s: SnmpDecodePacket() err returned: %v", funcName, err)
 			}
 
-			switch vb.Type {
-			case Integer, Gauge32, Counter32, TimeTicks, Counter64:
-				vbval := ToBigInt(vb.Value)
-				vbrval := ToBigInt(vbr.Value)
-				if vbval.Cmp(vbrval) != 0 {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			case OctetString:
-				if !bytes.Equal(vb.Value.([]byte), vbr.Value.([]byte)) {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			case IPAddress, ObjectIdentifier:
-				if vb.Value != vbr.Value {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			case Null, NoSuchObject, NoSuchInstance:
-				if (vb.Value != nil) || (vbr.Value != nil) {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			case OpaqueFloat:
-				if vb.Value.(float32) != vbr.Value.(float32) {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			case OpaqueDouble:
-				if vb.Value.(float64) != vbr.Value.(float64) {
-					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
-			default:
-				t.Errorf("#%d:%d Unhandled case result: %v, test: %v", i, n, vbr.Value, vb.Value)
+			// test "header" fields
+			if res.Version != test.out.Version {
+				t.Errorf("#%d Version result: %v, test: %v", i, res.Version, test.out.Version)
+			}
+			if res.Community != test.out.Community {
+				t.Errorf("#%d Community result: %v, test: %v", i, res.Community, test.out.Community)
+			}
+			if res.PDUType != test.out.PDUType {
+				t.Errorf("#%d PDUType result: %v, test: %v", i, res.PDUType, test.out.PDUType)
+			}
+			if res.RequestID != test.out.RequestID {
+				t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
+			}
+			if res.Error != test.out.Error {
+				t.Errorf("#%d Error result: %v, test: %v", i, res.Error, test.out.Error)
+			}
+			if res.ErrorIndex != test.out.ErrorIndex {
+				t.Errorf("#%d ErrorIndex result: %v, test: %v", i, res.ErrorIndex, test.out.ErrorIndex)
 			}
 
-		}
+			// test varbind values
+			for n, vb := range test.out.Variables {
+				if len(res.Variables) < n {
+					t.Errorf("#%d:%d ran out of varbind results", i, n)
+					return
+				}
+				vbr := res.Variables[n]
+
+				if vbr.Name != vb.Name {
+					t.Errorf("#%d:%d Name result: %v, test: %v", i, n, vbr.Name, vb.Name)
+				}
+				if vbr.Type != vb.Type {
+					t.Errorf("#%d:%d Type result: %v, test: %v", i, n, vbr.Type, vb.Type)
+				}
+
+				switch vb.Type {
+				case Integer, Gauge32, Counter32, TimeTicks, Counter64:
+					vbval := ToBigInt(vb.Value)
+					vbrval := ToBigInt(vbr.Value)
+					if vbval.Cmp(vbrval) != 0 {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				case OctetString:
+					if !bytes.Equal(vb.Value.([]byte), vbr.Value.([]byte)) {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				case IPAddress, ObjectIdentifier:
+					if vb.Value != vbr.Value {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				case Null, NoSuchObject, NoSuchInstance:
+					if (vb.Value != nil) || (vbr.Value != nil) {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				case OpaqueFloat:
+					if vb.Value.(float32) != vbr.Value.(float32) {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				case OpaqueDouble:
+					if vb.Value.(float64) != vbr.Value.(float64) {
+						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+				default:
+					t.Errorf("#%d:%d Unhandled case result: %v, test: %v", i, n, vbr.Value, vb.Value)
+				}
+
+			}
+		})
+
 	}
 }
 
@@ -1309,6 +1329,33 @@ func TestUnmarshalEmptyPanic(t *testing.T) {
 	}
 }
 
+func TestV3USMInitialPacket(t *testing.T) {
+	logger := log.New(ioutil.Discard, "", 0)
+	var emptyPdus []SnmpPDU
+	blankPacket := &SnmpPacket{
+		Version:            Version3,
+		MsgFlags:           Reportable | NoAuthNoPriv,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: &UsmSecurityParameters{Logger: logger},
+		PDUType:            GetRequest,
+		Logger:             logger,
+		Variables:          emptyPdus,
+	}
+	iBytes, err := blankPacket.marshalMsg()
+	if err != nil {
+		t.Errorf("#TestV3USMInitialPacket: marshalMsg() err returned: %v", err)
+	}
+	engine := GoSNMP{Logger: logger}
+	pktNew, errDecode := engine.SnmpDecodePacket(iBytes)
+	if errDecode != nil {
+		t.Logf("-->Bytes=%v", iBytes)
+		t.Logf("-->Expect=%v", blankPacket)
+		t.Logf("-->got=%v", pktNew)
+		t.Errorf("#TestV3USMInitialPacket: SnmpDecodePacket() err returned: %v. ", errDecode)
+	}
+
+}
+
 func TestSendOneRequest_dups(t *testing.T) {
 	srvr, err := net.ListenUDP("udp4", &net.UDPAddr{})
 	defer srvr.Close()
@@ -1490,6 +1537,78 @@ func trap1() []byte {
 		0x27, 0x0c, 0x03, 0x00, 0x08, 0x00, 0x74, 0x3a, 0x05, 0x00, 0x18, 0x94, 0x67, 0x0c, 0x04, 0x00,
 		0x08, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x08, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6c, 0x00, 0x00, 0x00}
+}
+
+// Simple Network Management Protocol
+//     msgVersion: snmpv3 (3)
+//     msgGlobalData
+//         msgID: 91040642
+//         msgMaxSize: 65507
+//         msgFlags: 04
+//         msgSecurityModel: USM (3)
+//     msgAuthoritativeEngineID: <MISSING>
+//     msgAuthoritativeEngineBoots: 0
+//     msgAuthoritativeEngineTime: 0
+//     msgUserName:
+//     msgAuthenticationParameters: <MISSING>
+//     msgPrivacyParameters: <MISSING>
+//     msgData: plaintext (0)
+//         plaintext
+
+func snmpv3HelloRequest() []byte {
+	return []byte{0x30, 0x52, 0x02, 0x01, 0x03, 0x30, 0x11, 0x02,
+		0x04, 0x05, 0x6d, 0x2b, 0x82, 0x02, 0x03, 0x00,
+		0xff, 0xe3, 0x04, 0x01, 0x04, 0x02, 0x01, 0x03,
+		0x04, 0x10, 0x30, 0x0e, 0x04, 0x00, 0x02, 0x01,
+		0x00, 0x02, 0x01, 0x00, 0x04, 0x00, 0x04, 0x00,
+		0x04, 0x00, 0x30, 0x28, 0x04, 0x00, 0x04, 0x14,
+		0x66, 0x6f, 0x72, 0x65, 0x69, 0x67, 0x6e, 0x66,
+		0x6f, 0x72, 0x6d, 0x61, 0x74, 0x73, 0x2f, 0x6c,
+		0x69, 0x6e, 0x75, 0x78, 0xa0, 0x0e, 0x02, 0x04,
+		0x44, 0xfa, 0x16, 0xe1, 0x02, 0x01, 0x00, 0x02,
+		0x01, 0x00, 0x30, 0x00}
+}
+
+// msgData: plaintext (0)
+//     plaintext
+//         contextEngineID: 80004fb8054445534b544f502d4a3732533245343ab63bc8
+//             1... .... = Engine ID Conformance: RFC3411 (SNMPv3)
+//             Engine Enterprise ID: pysnmp (20408)
+//             Engine ID Format: Octets, administratively assigned (5)
+//             Engine ID Data: 4445534b544f502d4a3732533245343ab63bc8
+//         contextName: foreignformats/linux
+//         data: report (8)
+//             report
+//                 request-id: 1157240545
+//                 error-status: noError (0)
+//                 error-index: 0
+//                 variable-bindings: 1 item
+//                     1.3.6.1.6.3.15.1.1.4.0: 21
+//                         Object Name: 1.3.6.1.6.3.15.1.1.4.0 (iso.3.6.1.6.3.15.1.1.4.0)
+//                         Value (Counter32): 21
+
+func snmpv3HelloResponse() []byte {
+	return []byte{
+		0x30, 0x81, 0x95, 0x02, 0x01, 0x03, 0x30, 0x11,
+		0x02, 0x04, 0x05, 0x6d, 0x2b, 0x82, 0x02, 0x03,
+		0x00, 0xff, 0xe3, 0x04, 0x01, 0x00, 0x02, 0x01,
+		0x03, 0x04, 0x2a, 0x30, 0x28, 0x04, 0x18, 0x80,
+		0x00, 0x4f, 0xb8, 0x05, 0x44, 0x45, 0x53, 0x4b,
+		0x54, 0x4f, 0x50, 0x2d, 0x4a, 0x37, 0x32, 0x53,
+		0x32, 0x45, 0x34, 0x3a, 0xb6, 0x3b, 0xc8, 0x02,
+		0x01, 0x02, 0x02, 0x03, 0x00, 0xc4, 0x7a, 0x04,
+		0x00, 0x04, 0x00, 0x04, 0x00, 0x30, 0x51, 0x04,
+		0x18, 0x80, 0x00, 0x4f, 0xb8, 0x05, 0x44, 0x45,
+		0x53, 0x4b, 0x54, 0x4f, 0x50, 0x2d, 0x4a, 0x37,
+		0x32, 0x53, 0x32, 0x45, 0x34, 0x3a, 0xb6, 0x3b,
+		0xc8, 0x04, 0x14, 0x66, 0x6f, 0x72, 0x65, 0x69,
+		0x67, 0x6e, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
+		0x73, 0x2f, 0x6c, 0x69, 0x6e, 0x75, 0x78, 0xa8,
+		0x1f, 0x02, 0x04, 0x44, 0xfa, 0x16, 0xe1, 0x02,
+		0x01, 0x00, 0x02, 0x01, 0x00, 0x30, 0x11, 0x30,
+		0x0f, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x06, 0x03,
+		0x0f, 0x01, 0x01, 0x04, 0x00, 0x41, 0x01, 0x15,
+	}
 }
 
 // dump bytes in a format similar to Wireshark

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Tests in alphabetical order of function being tested
@@ -726,74 +728,87 @@ func TestUnmarshal(t *testing.T) {
 			if err != nil {
 				t.Errorf("#%s: SnmpDecodePacket() err returned: %v", funcName, err)
 			}
-
-			// test "header" fields
-			if res.Version != test.out.Version {
-				t.Errorf("#%d Version result: %v, test: %v", i, res.Version, test.out.Version)
-			}
-			if res.Community != test.out.Community {
-				t.Errorf("#%d Community result: %v, test: %v", i, res.Community, test.out.Community)
-			}
-			if res.PDUType != test.out.PDUType {
-				t.Errorf("#%d PDUType result: %v, test: %v", i, res.PDUType, test.out.PDUType)
-			}
-			if res.RequestID != test.out.RequestID {
-				t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
-			}
-			if res.Error != test.out.Error {
-				t.Errorf("#%d Error result: %v, test: %v", i, res.Error, test.out.Error)
-			}
-			if res.ErrorIndex != test.out.ErrorIndex {
-				t.Errorf("#%d ErrorIndex result: %v, test: %v", i, res.ErrorIndex, test.out.ErrorIndex)
-			}
-
-			// test varbind values
-			for n, vb := range test.out.Variables {
-				if len(res.Variables) < n {
-					t.Errorf("#%d:%d ran out of varbind results", i, n)
-					return
+			t.Run("unmarshal", func(t *testing.T) {
+				// test "header" fields
+				if res.Version != test.out.Version {
+					t.Errorf("#%d Version result: %v, test: %v", i, res.Version, test.out.Version)
 				}
-				vbr := res.Variables[n]
-
-				if vbr.Name != vb.Name {
-					t.Errorf("#%d:%d Name result: %v, test: %v", i, n, vbr.Name, vb.Name)
+				if res.Community != test.out.Community {
+					t.Errorf("#%d Community result: %v, test: %v", i, res.Community, test.out.Community)
 				}
-				if vbr.Type != vb.Type {
-					t.Errorf("#%d:%d Type result: %v, test: %v", i, n, vbr.Type, vb.Type)
+				if res.PDUType != test.out.PDUType {
+					t.Errorf("#%d PDUType result: %v, test: %v", i, res.PDUType, test.out.PDUType)
+				}
+				if res.RequestID != test.out.RequestID {
+					t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
+				}
+				if res.Error != test.out.Error {
+					t.Errorf("#%d Error result: %v, test: %v", i, res.Error, test.out.Error)
+				}
+				if res.ErrorIndex != test.out.ErrorIndex {
+					t.Errorf("#%d ErrorIndex result: %v, test: %v", i, res.ErrorIndex, test.out.ErrorIndex)
 				}
 
-				switch vb.Type {
-				case Integer, Gauge32, Counter32, TimeTicks, Counter64:
-					vbval := ToBigInt(vb.Value)
-					vbrval := ToBigInt(vbr.Value)
-					if vbval.Cmp(vbrval) != 0 {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+				// test varbind values
+				for n, vb := range test.out.Variables {
+					if len(res.Variables) < n {
+						t.Errorf("#%d:%d ran out of varbind results", i, n)
+						return
 					}
-				case OctetString:
-					if !bytes.Equal(vb.Value.([]byte), vbr.Value.([]byte)) {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-					}
-				case IPAddress, ObjectIdentifier:
-					if vb.Value != vbr.Value {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-					}
-				case Null, NoSuchObject, NoSuchInstance:
-					if (vb.Value != nil) || (vbr.Value != nil) {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-					}
-				case OpaqueFloat:
-					if vb.Value.(float32) != vbr.Value.(float32) {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-					}
-				case OpaqueDouble:
-					if vb.Value.(float64) != vbr.Value.(float64) {
-						t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
-					}
-				default:
-					t.Errorf("#%d:%d Unhandled case result: %v, test: %v", i, n, vbr.Value, vb.Value)
-				}
+					vbr := res.Variables[n]
 
-			}
+					if vbr.Name != vb.Name {
+						t.Errorf("#%d:%d Name result: %v, test: %v", i, n, vbr.Name, vb.Name)
+					}
+					if vbr.Type != vb.Type {
+						t.Errorf("#%d:%d Type result: %v, test: %v", i, n, vbr.Type, vb.Type)
+					}
+
+					switch vb.Type {
+					case Integer, Gauge32, Counter32, TimeTicks, Counter64:
+						vbval := ToBigInt(vb.Value)
+						vbrval := ToBigInt(vbr.Value)
+						if vbval.Cmp(vbrval) != 0 {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					case OctetString:
+						if !bytes.Equal(vb.Value.([]byte), vbr.Value.([]byte)) {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					case IPAddress, ObjectIdentifier:
+						if vb.Value != vbr.Value {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					case Null, NoSuchObject, NoSuchInstance:
+						if (vb.Value != nil) || (vbr.Value != nil) {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					case OpaqueFloat:
+						if vb.Value.(float32) != vbr.Value.(float32) {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					case OpaqueDouble:
+						if vb.Value.(float64) != vbr.Value.(float64) {
+							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+						}
+					default:
+						t.Errorf("#%d:%d Unhandled case result: %v, test: %v", i, n, vbr.Value, vb.Value)
+					}
+
+				}
+			})
+			t.Run("remarshal", func(t *testing.T) {
+				result, err := res.marshalMsg()
+				if err != nil {
+					t.Fatalf("#%s: marshalMsg() err returned: %v", funcName, err)
+				}
+				resNew, err := vhandle.SnmpDecodePacket(result)
+				if err != nil {
+					t.Fatalf("#%s: SnmpDecodePacket() err returned: %v", funcName, err)
+				}
+				assert.EqualValues(t, res, resNew)
+
+			})
 		})
 
 	}

--- a/v3.go
+++ b/v3.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"runtime"
 )
 
 // SnmpV3MsgFlags contains various message flags to describe Authentication, Privacy, and whether a report PDU must be sent.
@@ -67,7 +68,9 @@ func (x *GoSNMP) validateParametersV3() error {
 func (packet *SnmpPacket) authenticate(msg []byte) ([]byte, error) {
 	defer func() {
 		if e := recover(); e != nil {
-			fmt.Printf("recover: %v\n", e)
+			var buf = make([]byte, 8192)
+			runtime.Stack(buf, true)
+			fmt.Printf("[v3::authenticate]recover: %v. Stack=%v\n", e, string(buf))
 		}
 	}()
 	if packet.Version != Version3 {
@@ -194,6 +197,7 @@ func (packet *SnmpPacket) marshalV3(buf *bytes.Buffer) (*bytes.Buffer, error) {
 		return emptyBuffer, err
 	}
 	buf.Write([]byte{byte(Sequence), byte(len(header))})
+	packet.logPrintf("Marshal V3 Header len=%d. Eaten Last 4 Bytes=%v", len(header), header[len(header)-4:])
 	buf.Write(header)
 
 	var securityParameters []byte
@@ -201,6 +205,8 @@ func (packet *SnmpPacket) marshalV3(buf *bytes.Buffer) (*bytes.Buffer, error) {
 	if err != nil {
 		return emptyBuffer, err
 	}
+	packet.logPrintf("Marshal V3 SecurityParameters len=%d. Eaten Last 4 Bytes=%v",
+		len(securityParameters), securityParameters[len(securityParameters)-4:])
 
 	buf.Write([]byte{byte(OctetString)})
 	secParamLen, err := marshalLength(len(securityParameters))
@@ -228,17 +234,28 @@ func (packet *SnmpPacket) marshalV3Header() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	oldLen := 0
+	packet.logPrintf("MarshalV3Header msgID len=%v", buf.Len()-oldLen)
+	oldLen = buf.Len()
 	// maximum response msg size
 	maxmsgsize := marshalUvarInt(rxBufSize)
 	buf.Write([]byte{byte(Integer), byte(len(maxmsgsize))})
 	buf.Write(maxmsgsize)
 
+	packet.logPrintf("MarshalV3Header maxmsgsize len=%v", buf.Len()-oldLen)
+	oldLen = buf.Len()
+
 	// msg flags
 	buf.Write([]byte{byte(OctetString), 1, byte(packet.MsgFlags)})
 
+	packet.logPrintf("MarshalV3Header msg flags len=%v", buf.Len()-oldLen)
+	oldLen = buf.Len()
+
 	// msg security model
 	buf.Write([]byte{byte(Integer), 1, byte(packet.SecurityModel)})
+
+	packet.logPrintf("MarshalV3Header msg security model len=%v", buf.Len()-oldLen)
+	oldLen = buf.Len()
 
 	return buf.Bytes(), nil
 }
@@ -373,13 +390,15 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	if cursor > len(packet) {
 		return 0, fmt.Errorf("Error parsing SNMPV3 message ID: truncted packet")
 	}
-
-	if response.SecurityParameters != nil {
-		cursor, err = response.SecurityParameters.unmarshal(response.MsgFlags, packet, cursor)
-		if err != nil {
-			return 0, err
-		}
+	if response.SecurityParameters == nil {
+		response.SecurityParameters = &UsmSecurityParameters{Logger: x.Logger}
 	}
+
+	cursor, err = response.SecurityParameters.unmarshal(response.MsgFlags, packet, cursor)
+	if err != nil {
+		return 0, err
+	}
+	x.logPrintf("Parsed Security Parameters. now offset=%v,", cursor)
 
 	return cursor, nil
 }

--- a/v3.go
+++ b/v3.go
@@ -238,10 +238,13 @@ func (packet *SnmpPacket) marshalV3Header() ([]byte, error) {
 	packet.logPrintf("MarshalV3Header msgID len=%v", buf.Len()-oldLen)
 	oldLen = buf.Len()
 	// maximum response msg size
-	maxmsgsize := marshalUvarInt(rxBufSize)
+	var maxBufSize uint32 = rxBufSize
+	if packet.MsgMaxSize != 0 {
+		maxBufSize = packet.MsgMaxSize
+	}
+	maxmsgsize := marshalUvarInt(maxBufSize)
 	buf.Write([]byte{byte(Integer), byte(len(maxmsgsize))})
 	buf.Write(maxmsgsize)
-
 	packet.logPrintf("MarshalV3Header maxmsgsize len=%v", buf.Len()-oldLen)
 	oldLen = buf.Len()
 

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -448,7 +448,7 @@ func (sp *UsmSecurityParameters) authenticate(packet []byte) error {
 
 	authParamStart, err := usmFindAuthParamStart(packet)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	copy(packet[authParamStart:authParamStart+12], h2.Sum(nil)[:12])
@@ -644,10 +644,20 @@ func (sp *UsmSecurityParameters) marshal(flags SnmpV3MsgFlags) ([]byte, error) {
 
 	// msgAuthenticationParameters
 	if flags&AuthNoPriv > 0 {
-		buf.Write([]byte{byte(OctetString), 12,
-			0, 0, 0, 0,
-			0, 0, 0, 0,
-			0, 0, 0, 0})
+		if len(sp.AuthenticationParameters) == 0 {
+			buf.Write([]byte{byte(OctetString), 12,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0})
+		} else {
+			authlen, err := marshalLength(len(sp.AuthenticationParameters))
+			if err != nil {
+				return nil, err
+			}
+			buf.Write([]byte{byte(OctetString)})
+			buf.Write(authlen)
+			buf.Write([]byte(sp.AuthenticationParameters))
+		}
 	} else {
 		buf.Write([]byte{byte(OctetString), 0})
 	}


### PR DESCRIPTION
 Allow to decode snmp request packets.

1. Allow `SnmpDecodePacket` for: `GetRequest`, `SetRequest`, `InformRequest`
2. Allow `SnmpDecodePacket` for snmpv3 initial blank packet.(blank packet to discover authoriative engine ID/boots/time)
3. Allow to marshal `Counter64`, `OpaqueFloat`, `OpaqueDouble`, `BitString`
4. Allow to marshal `NoSuchInstance`, `NoSuchObject`, `EndOfMibView`
5. Allow to marshal packet errors.
6. For tests it work property. adds unittest.
7. Fix code for unittest to works appropriately.
8. Debugging outputs