### PR TITLE
v3.go: allow trap for initial param discovery

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -128,7 +128,8 @@ func (x *GoSNMP) negotiateInitialSecurityParameters(packetOut *SnmpPacket, wait 
 	}
 
 	if discoveryPacket := packetOut.SecurityParameters.discoveryRequired(); discoveryPacket != nil {
-		result, err := x.sendOneRequest(discoveryPacket, wait)
+		discoveryPacket.ContextName = x.ContextName
+		result, err := x.sendOneRequest(discoveryPacket, true)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
v3.go:

- Allows trap for initial param discovery.
- Allow initial param discovery with ContextName

fix: https://github.com/soniah/gosnmp/issues/145

Test available at https://github.com/slayercat/GoSNMPServer/blob/d00d4db40ff320b992fec9d9d72d69b66304559f/snmpserverTraps_test.go#L134