### PR TITLE
Fixed a bug with PrivacyKey and SecretKey calculation

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -318,7 +318,8 @@ func (x *GoSNMP) validateParameters() error {
 func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) *SnmpPacket {
 	var newSecParams SnmpV3SecurityParameters
 	if x.SecurityParameters != nil {
-		newSecParams = x.SecurityParameters.Copy()
+		newSecParams = Default.SecurityParameters
+		newSecParams.setSecurityParameters(x.SecurityParameters)
 	}
 	return &SnmpPacket{
 		Version:            x.Version,

--- a/trap_test.go
+++ b/trap_test.go
@@ -413,6 +413,7 @@ func TestSendV3TrapNoAuthNoPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           NoAuthNoPriv,
 	}
 
 	err := ts.Connect()
@@ -498,6 +499,7 @@ func TestSendV3TrapMD5AuthNoPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthNoPriv,
 	}
 
 	err := ts.Connect()
@@ -583,6 +585,7 @@ func TestSendV3TrapSHAAuthNoPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthNoPriv,
 	}
 
 	err := ts.Connect()
@@ -670,6 +673,7 @@ func TestSendV3TrapSHAAuthAESPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()
@@ -756,6 +760,7 @@ func TestSendV3TrapSHAAuthDESPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()
@@ -842,6 +847,7 @@ func TestSendV3TrapSHAAuthAES192Priv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()
@@ -928,6 +934,7 @@ func TestSendV3TrapSHAAuthAES192CPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()
@@ -1013,6 +1020,7 @@ func TestSendV3TrapSHAAuthAES256Priv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()
@@ -1099,6 +1107,7 @@ func TestSendV3TrapSHAAuthAES256CPriv(t *testing.T) {
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
 		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
 	}
 
 	err := ts.Connect()

--- a/trap_test.go
+++ b/trap_test.go
@@ -366,3 +366,258 @@ func TestSendV1Trap(t *testing.T) {
 	}
 
 }
+
+func TestSendV3TrapNoAuthNoPriv(t *testing.T) {
+	done := make(chan int)
+
+	tl := NewTrapListener()
+	defer tl.Close()
+
+	sp := &UsmSecurityParameters{
+		UserName:                 "test",
+		AuthoritativeEngineBoots: 1,
+		AuthoritativeEngineTime:  1,
+		AuthoritativeEngineID:    string([]byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04}),
+	}
+
+	tl.OnNewTrap = makeTestTrapHandler(t, done, Version3)
+	tl.Params = Default
+	tl.Params.Version = Version3
+	tl.Params.SecurityParameters = sp
+	tl.Params.SecurityModel = UserSecurityModel
+	tl.Params.MsgFlags = NoAuthNoPriv
+
+	// listener goroutine
+	errch := make(chan error)
+	go func() {
+		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		if err != nil {
+			errch <- err
+		}
+	}()
+
+	// Wait until the listener is ready.
+	select {
+	case <-tl.Listening():
+	case err := <-errch:
+		t.Fatalf("error in listen: %v", err)
+	}
+
+	ts := &GoSNMP{
+		Target: trapTestAddress,
+		Port:   trapTestPort,
+		//Community: "public",
+		Version:            Version3,
+		Timeout:            time.Duration(2) * time.Second,
+		Retries:            3,
+		MaxOids:            MaxOids,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: sp,
+	}
+
+	err := ts.Connect()
+	if err != nil {
+		t.Fatalf("Connect() err: %v", err)
+	}
+	defer ts.Conn.Close()
+
+	pdu := SnmpPDU{
+		Name:  trapTestOid,
+		Type:  OctetString,
+		Value: trapTestPayload,
+	}
+
+	trap := SnmpTrap{
+		Variables:    []SnmpPDU{pdu},
+		Enterprise:   trapTestEnterpriseOid,
+		AgentAddress: trapTestAgentAddress,
+		GenericTrap:  trapTestGenericTrap,
+		SpecificTrap: trapTestSpecificTrap,
+		Timestamp:    trapTestTimestamp,
+	}
+
+	_, err = ts.SendTrap(trap)
+	if err != nil {
+		t.Fatalf("SendTrap() err: %v", err)
+	}
+
+	// wait for response from handler
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trap to be received")
+	}
+
+}
+
+func TestSendV3TrapAuthNoPriv(t *testing.T) {
+	done := make(chan int)
+
+	tl := NewTrapListener()
+	defer tl.Close()
+
+	sp := &UsmSecurityParameters{
+		UserName:                 "test",
+		AuthenticationProtocol:   SHA,
+		AuthenticationPassphrase: "password",
+		AuthoritativeEngineBoots: 1,
+		AuthoritativeEngineTime:  1,
+		AuthoritativeEngineID:    string([]byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04}),
+	}
+
+	tl.OnNewTrap = makeTestTrapHandler(t, done, Version3)
+	tl.Params = Default
+	tl.Params.Version = Version3
+	tl.Params.SecurityParameters = sp
+	tl.Params.SecurityModel = UserSecurityModel
+	tl.Params.MsgFlags = AuthNoPriv
+
+	// listener goroutine
+	errch := make(chan error)
+	go func() {
+		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		if err != nil {
+			errch <- err
+		}
+	}()
+
+	// Wait until the listener is ready.
+	select {
+	case <-tl.Listening():
+	case err := <-errch:
+		t.Fatalf("error in listen: %v", err)
+	}
+
+	ts := &GoSNMP{
+		Target: trapTestAddress,
+		Port:   trapTestPort,
+		//Community: "public",
+		Version:            Version3,
+		Timeout:            time.Duration(2) * time.Second,
+		Retries:            3,
+		MaxOids:            MaxOids,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: sp,
+	}
+
+	err := ts.Connect()
+	if err != nil {
+		t.Fatalf("Connect() err: %v", err)
+	}
+	defer ts.Conn.Close()
+
+	pdu := SnmpPDU{
+		Name:  trapTestOid,
+		Type:  OctetString,
+		Value: trapTestPayload,
+	}
+
+	trap := SnmpTrap{
+		Variables:    []SnmpPDU{pdu},
+		Enterprise:   trapTestEnterpriseOid,
+		AgentAddress: trapTestAgentAddress,
+		GenericTrap:  trapTestGenericTrap,
+		SpecificTrap: trapTestSpecificTrap,
+		Timestamp:    trapTestTimestamp,
+	}
+
+	_, err = ts.SendTrap(trap)
+	if err != nil {
+		t.Fatalf("SendTrap() err: %v", err)
+	}
+
+	// wait for response from handler
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trap to be received")
+	}
+
+}
+
+func TestSendV3TrapAuthPriv(t *testing.T) {
+	done := make(chan int)
+
+	tl := NewTrapListener()
+	defer tl.Close()
+
+	sp := &UsmSecurityParameters{
+		UserName:                 "test",
+		AuthenticationProtocol:   SHA,
+		AuthenticationPassphrase: "password",
+		PrivacyProtocol:          AES,
+		PrivacyPassphrase:        "password",
+		AuthoritativeEngineBoots: 1,
+		AuthoritativeEngineTime:  1,
+		AuthoritativeEngineID:    string([]byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04}),
+	}
+
+	tl.OnNewTrap = makeTestTrapHandler(t, done, Version3)
+	tl.Params = Default
+	tl.Params.Version = Version3
+	tl.Params.SecurityParameters = sp
+	tl.Params.SecurityModel = UserSecurityModel
+	tl.Params.MsgFlags = AuthNoPriv
+
+	// listener goroutine
+	errch := make(chan error)
+	go func() {
+		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		if err != nil {
+			errch <- err
+		}
+	}()
+
+	// Wait until the listener is ready.
+	select {
+	case <-tl.Listening():
+	case err := <-errch:
+		t.Fatalf("error in listen: %v", err)
+	}
+
+	ts := &GoSNMP{
+		Target: trapTestAddress,
+		Port:   trapTestPort,
+		//Community: "public",
+		Version:            Version3,
+		Timeout:            time.Duration(2) * time.Second,
+		Retries:            3,
+		MaxOids:            MaxOids,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: sp,
+	}
+
+	err := ts.Connect()
+	if err != nil {
+		t.Fatalf("Connect() err: %v", err)
+	}
+	defer ts.Conn.Close()
+
+	pdu := SnmpPDU{
+		Name:  trapTestOid,
+		Type:  OctetString,
+		Value: trapTestPayload,
+	}
+
+	trap := SnmpTrap{
+		Variables:    []SnmpPDU{pdu},
+		Enterprise:   trapTestEnterpriseOid,
+		AgentAddress: trapTestAgentAddress,
+		GenericTrap:  trapTestGenericTrap,
+		SpecificTrap: trapTestSpecificTrap,
+		Timestamp:    trapTestTimestamp,
+	}
+
+	_, err = ts.SendTrap(trap)
+	if err != nil {
+		t.Fatalf("SendTrap() err: %v", err)
+	}
+
+	// wait for response from handler
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trap to be received")
+	}
+
+}

--- a/trap_test.go
+++ b/trap_test.go
@@ -459,7 +459,7 @@ func TestSendV3TrapMD5AuthNoPriv(t *testing.T) {
 
 	sp := &UsmSecurityParameters{
 		UserName:                 "test",
-		AuthenticationProtocol:   SHA,
+		AuthenticationProtocol:   MD5,
 		AuthenticationPassphrase: "password",
 		AuthoritativeEngineBoots: 1,
 		AuthoritativeEngineTime:  1,

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -112,32 +112,32 @@ func (sp *UsmSecurityParameters) setSecurityParameters(in SnmpV3SecurityParamete
 
 	if sp.AuthoritativeEngineID != insp.AuthoritativeEngineID {
 		sp.AuthoritativeEngineID = insp.AuthoritativeEngineID
-		if sp.AuthenticationProtocol > NoAuth && len(sp.SecretKey) == 0 {
-			sp.SecretKey, err = genlocalkey(sp.AuthenticationProtocol,
-				sp.AuthenticationPassphrase,
+	}
+	if sp.AuthenticationProtocol > NoAuth && len(sp.SecretKey) == 0 {
+		sp.SecretKey, err = genlocalkey(sp.AuthenticationProtocol,
+			sp.AuthenticationPassphrase,
+			sp.AuthoritativeEngineID)
+		if err != nil {
+			return err
+		}
+	}
+	if sp.PrivacyProtocol > NoPriv && len(sp.PrivacyKey) == 0 {
+		switch sp.PrivacyProtocol {
+		// Changed: The Output of SHA1 is a 20 octets array, therefore for AES128 (16 octets) either key extension algorithm can be used.
+		case AES, AES192, AES256, AES192C, AES256C:
+			//Use abstract AES key localization algorithms
+			sp.PrivacyKey, err = genlocalPrivKey(sp.PrivacyProtocol, sp.AuthenticationProtocol,
+				sp.PrivacyPassphrase,
 				sp.AuthoritativeEngineID)
 			if err != nil {
 				return err
 			}
-		}
-		if sp.PrivacyProtocol > NoPriv && len(sp.PrivacyKey) == 0 {
-			switch sp.PrivacyProtocol {
-			// Changed: The Output of SHA1 is a 20 octets array, therefore for AES128 (16 octets) either key extension algorithm can be used.
-			case AES, AES192, AES256, AES192C, AES256C:
-				//Use abstract AES key localization algorithms
-				sp.PrivacyKey, err = genlocalPrivKey(sp.PrivacyProtocol, sp.AuthenticationProtocol,
-					sp.PrivacyPassphrase,
-					sp.AuthoritativeEngineID)
-				if err != nil {
-					return err
-				}
-			default:
-				sp.PrivacyKey, err = genlocalkey(sp.AuthenticationProtocol,
-					sp.PrivacyPassphrase,
-					sp.AuthoritativeEngineID)
-				if err != nil {
-					return err
-				}
+		default:
+			sp.PrivacyKey, err = genlocalkey(sp.AuthenticationProtocol,
+				sp.PrivacyPassphrase,
+				sp.AuthoritativeEngineID)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
If sp.AuthoritativeEngineID matches insp.AuthoritativeEngineID, then SecretKey and PrivacyKey are not generated. Therefore, receiving and sending authenticated and/or encrypted packets fails.

The pull request fixes the issue by not having key generation depending on the AuthoritativeEngineID-condition and altering how security parameters are set when sending traps.
I also added tests for SNMPv3 Traps and it passes all local tests.