### PR TITLE
Fixes #229 and #228

### DIFF
--- a/examples/trapsend_v3.go
+++ b/examples/trapsend_v3.go
@@ -1,0 +1,57 @@
+// Copyright 2012-2014 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	g "github.com/soniah/gosnmp"
+)
+
+func main() {
+
+	// Default is a pointer to a GoSNMP struct that contains sensible defaults
+	// eg port 161, community public, etc
+
+	params := &g.GoSNMP{
+		Target:        "127.0.0.1",
+		Port:          162,
+		Version:       g.Version3,
+		Timeout:       time.Duration(30) * time.Second,
+		SecurityModel: g.UserSecurityModel,
+		MsgFlags:      g.AuthPriv,
+		Logger:        log.New(os.Stdout, "", 0),
+		SecurityParameters: &g.UsmSecurityParameters{UserName: "user",
+			AuthoritativeEngineID:    "1234",
+			AuthenticationProtocol:   g.SHA,
+			AuthenticationPassphrase: "password",
+			PrivacyProtocol:          g.DES,
+			PrivacyPassphrase:        "password",
+		},
+	}
+
+	err := params.Connect()
+	if err != nil {
+		log.Fatalf("Connect() err: %v", err)
+	}
+	defer params.Conn.Close()
+
+	pdu := g.SnmpPDU{
+		Name:  ".1.3.6.1.6.3.1.1.4.1.0",
+		Type:  g.ObjectIdentifier,
+		Value: ".1.3.6.1.6.3.1.1.5.1",
+	}
+
+	trap := g.SnmpTrap{
+		Variables: []g.SnmpPDU{pdu},
+	}
+
+	_, err = params.SendTrap(trap)
+	if err != nil {
+		log.Fatalf("SendTrap() err: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/soniah/gosnmp
 
+
 require (
 	github.com/golang/mock v1.2.0
 	github.com/stretchr/testify v1.3.0

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -318,8 +318,7 @@ func (x *GoSNMP) validateParameters() error {
 func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, pdus []SnmpPDU, nonRepeaters uint8, maxRepetitions uint8) *SnmpPacket {
 	var newSecParams SnmpV3SecurityParameters
 	if x.SecurityParameters != nil {
-		newSecParams = Default.SecurityParameters
-		newSecParams.setSecurityParameters(x.SecurityParameters)
+		newSecParams = x.SecurityParameters.Copy()
 	}
 	return &SnmpPacket{
 		Version:            x.Version,

--- a/v3.go
+++ b/v3.go
@@ -50,6 +50,7 @@ type SnmpV3SecurityParameters interface {
 	isAuthentic(packetBytes []byte, packet *SnmpPacket) (bool, error)
 	encryptPacket(scopedPdu []byte) ([]byte, error)
 	decryptPacket(packet []byte, cursor int) ([]byte, error)
+	initSecurityKeys() error
 }
 
 func (x *GoSNMP) validateParametersV3() error {
@@ -142,6 +143,11 @@ func (x *GoSNMP) negotiateInitialSecurityParameters(packetOut *SnmpPacket, wait 
 
 		err = x.updatePktSecurityParameters(packetOut)
 		if err != nil {
+			return err
+		}
+	} else {
+		err := packetOut.SecurityParameters.initSecurityKeys()
+		if err == nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR fixes issues mentioned in #229 and #228 

The root cause of those issues was a quick and dirty attempt to fix sending SNMPv3 traps without discovery packets, which can be seen in gosnmp.go

The issue which I was originally trying to solve, was that when AuthoritativeEngineID was specified, the keys for privacy and authenticity were not generated. If AuthoritativeEngineID is not specified, then a discovery packet is sent, and the returning packet triggers the generation of previously mentioned keys. As the discovery is not required if AuthoritativeEngineID is specified, then the keys are not generated.

The correct way to fix this would be to check if discovery is needed, and if it is not, then initialize those keys.This PR implements this kind of logic. I've also included trapsend_v3.go to examples.

This PR passes all tests, and I have manually verified the examples to be working.