### PR TITLE
Update Retries comment to reflect code.

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -61,7 +61,7 @@ type GoSNMP struct {
 	// Timeout is the timeout for one SNMP request/response
 	Timeout time.Duration
 
-	// Set the number of retries to attempt within timeout
+	// Set the number of retries to attempt
 	Retries int
 
 	// Double timeout in each retry


### PR DESCRIPTION
The semantics were changed by cd9a07ae5a52ff5851e1cfed624e5415b6e9a6ee

This was discovered in https://github.com/prometheus/snmp_exporter/issues/507