### PR TITLE
Fix race conditions

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -40,6 +41,8 @@ const (
 
 // GoSNMP represents GoSNMP library state
 type GoSNMP struct {
+	mu sync.Mutex
+
 	// Conn is net connection to use, typically established using GoSNMP.Connect()
 	Conn net.Conn
 
@@ -290,6 +293,8 @@ func (x *GoSNMP) netConnect() error {
 
 func (x *GoSNMP) validateParameters() error {
 	if x.Logger == nil {
+		x.mu.Lock()
+		defer x.mu.Unlock()
 		x.Logger = log.New(ioutil.Discard, "", 0)
 	} else {
 		x.loggingEnabled = true
@@ -321,7 +326,6 @@ func (x *GoSNMP) validateParameters() error {
 	if x.Context == nil {
 		x.Context = context.Background()
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
fix #239 race conditions

```
 % go test -tags all -v -race
=== RUN   TestGenericBasicGet
    TestGenericBasicGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericBasicGet (0.00s)
=== RUN   TestGenericBasicGetIPv4Only
    TestGenericBasicGetIPv4Only: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericBasicGetIPv4Only (0.00s)
=== RUN   TestGenericMultiGet
    TestGenericMultiGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericMultiGet (0.00s)
=== RUN   TestGenericGetNext
    TestGenericGetNext: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericGetNext (0.00s)
=== RUN   TestGenericWalk
    TestGenericWalk: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericWalk (0.00s)
=== RUN   TestGenericBulkWalk
    TestGenericBulkWalk: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestGenericBulkWalk (0.00s)
=== RUN   TestMaxOids
    TestMaxOids: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestMaxOids (0.00s)
=== RUN   TestGenericFailureUnknownHost
--- PASS: TestGenericFailureUnknownHost (0.04s)
=== RUN   TestGenericFailureConnectionTimeout
    TestGenericFailureConnectionTimeout: generic_e2e_test.go:294: local testing - skipping this slow one
--- SKIP: TestGenericFailureConnectionTimeout (0.00s)
=== RUN   TestGenericFailureConnectionRefused
--- PASS: TestGenericFailureConnectionRefused (0.00s)
=== RUN   TestSnmpV3NoAuthNoPrivBasicGet
    TestSnmpV3NoAuthNoPrivBasicGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3NoAuthNoPrivBasicGet (0.00s)
=== RUN   TestSnmpV3AuthMD5NoPrivGet
    TestSnmpV3AuthMD5NoPrivGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthMD5NoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthMD5PrivAES256CGet
    TestSnmpV3AuthMD5PrivAES256CGet: v3_testing_credentials.go:141: No user credentials found for MD5/AES256C
--- SKIP: TestSnmpV3AuthMD5PrivAES256CGet (0.00s)
=== RUN   TestSnmpV3AuthSHANoPrivGet
    TestSnmpV3AuthSHANoPrivGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthSHANoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthSHAPrivAESGet
    TestSnmpV3AuthSHAPrivAESGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthSHAPrivAESGet (0.00s)
=== RUN   TestSnmpV3AuthSHAPrivAES256CGet
    TestSnmpV3AuthSHAPrivAES256CGet: v3_testing_credentials.go:141: No user credentials found for SHA/AES256C
--- SKIP: TestSnmpV3AuthSHAPrivAES256CGet (0.00s)
=== RUN   TestSnmpV3AuthSHA224NoPrivGet
    TestSnmpV3AuthSHA224NoPrivGet: generic_e2e_test.go:485: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA224NoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthSHA256NoPrivGet
    TestSnmpV3AuthSHA256NoPrivGet: generic_e2e_test.go:512: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA256NoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthSHA384NoPrivGet
    TestSnmpV3AuthSHA384NoPrivGet: generic_e2e_test.go:539: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA384NoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthSHA512NoPrivGet
    TestSnmpV3AuthSHA512NoPrivGet: generic_e2e_test.go:566: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA512NoPrivGet (0.00s)
=== RUN   TestSnmpV3AuthSHA512PrivAES192Get
    TestSnmpV3AuthSHA512PrivAES192Get: generic_e2e_test.go:592: AES-192 Blumenthal is currently known to have issues.
--- SKIP: TestSnmpV3AuthSHA512PrivAES192Get (0.00s)
=== RUN   TestSnmpV3AuthSHA512PrivAES192CGet
    TestSnmpV3AuthSHA512PrivAES192CGet: generic_e2e_test.go:623: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA512PrivAES192CGet (0.00s)
=== RUN   TestSnmpV3AuthSHA512PrivAES256CGet
    TestSnmpV3AuthSHA512PrivAES256CGet: generic_e2e_test.go:656: This test is currently only working when using demo.snmplabs.com as test device.
--- SKIP: TestSnmpV3AuthSHA512PrivAES256CGet (0.00s)
=== RUN   TestSnmpV3AuthMD5PrivDESGet
    TestSnmpV3AuthMD5PrivDESGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthMD5PrivDESGet (0.00s)
=== RUN   TestSnmpV3AuthSHAPrivDESGet
    TestSnmpV3AuthSHAPrivDESGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthSHAPrivDESGet (0.00s)
=== RUN   TestSnmpV3AuthMD5PrivAESGet
    TestSnmpV3AuthMD5PrivAESGet: generic_e2e_test.go:40: environment variable not set: GOSNMP_TARGET
--- SKIP: TestSnmpV3AuthMD5PrivAESGet (0.00s)
=== RUN   TestSnmpV3PrivEmptyPrivatePassword
--- PASS: TestSnmpV3PrivEmptyPrivatePassword (0.00s)
=== RUN   TestSnmpV3AuthNoPrivEmptyPrivatePassword
--- PASS: TestSnmpV3AuthNoPrivEmptyPrivatePassword (0.00s)
=== RUN   TestOidToString
--- PASS: TestOidToString (0.00s)
=== RUN   TestWithAnotherOid
--- PASS: TestWithAnotherOid (0.00s)
=== RUN   TestMarshalUint32
--- PASS: TestMarshalUint32 (0.00s)
=== RUN   TestMarshalInt32
--- PASS: TestMarshalInt32 (0.00s)
=== RUN   TestParseUint64
--- PASS: TestParseUint64 (0.00s)
=== RUN   TestInvalidSNMPResponses
--- PASS: TestInvalidSNMPResponses (0.00s)
=== RUN   TestEnmarshalVarbind
--- PASS: TestEnmarshalVarbind (0.00s)
=== RUN   TestEnmarshalVBL
--- PASS: TestEnmarshalVBL (0.00s)
=== RUN   TestEnmarshalPDU
--- PASS: TestEnmarshalPDU (0.00s)
=== RUN   TestEnmarshalMsg
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[160]/RequestID[1871507044]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[526895288]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1826072803]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[756726019]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1000552357]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1664317637]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[160]/RequestID[1883298028]
=== RUN   TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[167]/RequestID[1918693186]
--- PASS: TestEnmarshalMsg (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[160]/RequestID[1871507044] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[526895288] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1826072803] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[756726019] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1000552357] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[163]/RequestID[1664317637] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[160]/RequestID[1883298028] (0.00s)
    --- PASS: TestEnmarshalMsg/TestEnmarshalMsgUnmarshal/PDU[167]/RequestID[1918693186] (0.00s)
=== RUN   TestUnmarshal
=== RUN   TestUnmarshal/0-kyoceraResponseBytes
=== RUN   TestUnmarshal/0-kyoceraResponseBytes/unmarshal
=== RUN   TestUnmarshal/0-kyoceraResponseBytes/remarshal
=== RUN   TestUnmarshal/1-ciscoResponseBytes
=== RUN   TestUnmarshal/1-ciscoResponseBytes/unmarshal
=== RUN   TestUnmarshal/1-ciscoResponseBytes/remarshal
=== RUN   TestUnmarshal/2-portOnIncoming1
=== RUN   TestUnmarshal/2-portOnIncoming1/unmarshal
=== RUN   TestUnmarshal/2-portOnIncoming1/remarshal
=== RUN   TestUnmarshal/3-portOffIncoming1
=== RUN   TestUnmarshal/3-portOffIncoming1/unmarshal
=== RUN   TestUnmarshal/3-portOffIncoming1/remarshal
=== RUN   TestUnmarshal/4-ciscoGetnextResponseBytes
=== RUN   TestUnmarshal/4-ciscoGetnextResponseBytes/unmarshal
=== RUN   TestUnmarshal/4-ciscoGetnextResponseBytes/remarshal
=== RUN   TestUnmarshal/5-ciscoGetbulkResponseBytes
=== RUN   TestUnmarshal/5-ciscoGetbulkResponseBytes/unmarshal
=== RUN   TestUnmarshal/5-ciscoGetbulkResponseBytes/remarshal
=== RUN   TestUnmarshal/6-emptyErrResponse
=== RUN   TestUnmarshal/6-emptyErrResponse/unmarshal
=== RUN   TestUnmarshal/6-emptyErrResponse/remarshal
=== RUN   TestUnmarshal/7-counter64Response
=== RUN   TestUnmarshal/7-counter64Response/unmarshal
=== RUN   TestUnmarshal/7-counter64Response/remarshal
=== RUN   TestUnmarshal/8-opaqueFloatResponse
=== RUN   TestUnmarshal/8-opaqueFloatResponse/unmarshal
=== RUN   TestUnmarshal/8-opaqueFloatResponse/remarshal
=== RUN   TestUnmarshal/9-opaqueDoubleResponse
=== RUN   TestUnmarshal/9-opaqueDoubleResponse/unmarshal
=== RUN   TestUnmarshal/9-opaqueDoubleResponse/remarshal
=== RUN   TestUnmarshal/10-snmpv3HelloRequest
=== RUN   TestUnmarshal/10-snmpv3HelloRequest/unmarshal
=== RUN   TestUnmarshal/10-snmpv3HelloRequest/remarshal
=== RUN   TestUnmarshal/11-snmpv3HelloResponse
=== RUN   TestUnmarshal/11-snmpv3HelloResponse/unmarshal
=== RUN   TestUnmarshal/11-snmpv3HelloResponse/remarshal
--- PASS: TestUnmarshal (0.01s)
    --- PASS: TestUnmarshal/0-kyoceraResponseBytes (0.00s)
        --- PASS: TestUnmarshal/0-kyoceraResponseBytes/unmarshal (0.00s)
        --- PASS: TestUnmarshal/0-kyoceraResponseBytes/remarshal (0.00s)
    --- PASS: TestUnmarshal/1-ciscoResponseBytes (0.00s)
        --- PASS: TestUnmarshal/1-ciscoResponseBytes/unmarshal (0.00s)
        --- PASS: TestUnmarshal/1-ciscoResponseBytes/remarshal (0.00s)
    --- PASS: TestUnmarshal/2-portOnIncoming1 (0.00s)
        --- PASS: TestUnmarshal/2-portOnIncoming1/unmarshal (0.00s)
        --- PASS: TestUnmarshal/2-portOnIncoming1/remarshal (0.00s)
    --- PASS: TestUnmarshal/3-portOffIncoming1 (0.00s)
        --- PASS: TestUnmarshal/3-portOffIncoming1/unmarshal (0.00s)
        --- PASS: TestUnmarshal/3-portOffIncoming1/remarshal (0.00s)
    --- PASS: TestUnmarshal/4-ciscoGetnextResponseBytes (0.00s)
        --- PASS: TestUnmarshal/4-ciscoGetnextResponseBytes/unmarshal (0.00s)
        --- PASS: TestUnmarshal/4-ciscoGetnextResponseBytes/remarshal (0.00s)
    --- PASS: TestUnmarshal/5-ciscoGetbulkResponseBytes (0.00s)
        --- PASS: TestUnmarshal/5-ciscoGetbulkResponseBytes/unmarshal (0.00s)
        --- PASS: TestUnmarshal/5-ciscoGetbulkResponseBytes/remarshal (0.00s)
    --- PASS: TestUnmarshal/6-emptyErrResponse (0.00s)
        --- PASS: TestUnmarshal/6-emptyErrResponse/unmarshal (0.00s)
        --- PASS: TestUnmarshal/6-emptyErrResponse/remarshal (0.00s)
    --- PASS: TestUnmarshal/7-counter64Response (0.00s)
        --- PASS: TestUnmarshal/7-counter64Response/unmarshal (0.00s)
        --- PASS: TestUnmarshal/7-counter64Response/remarshal (0.00s)
    --- PASS: TestUnmarshal/8-opaqueFloatResponse (0.00s)
        --- PASS: TestUnmarshal/8-opaqueFloatResponse/unmarshal (0.00s)
        --- PASS: TestUnmarshal/8-opaqueFloatResponse/remarshal (0.00s)
    --- PASS: TestUnmarshal/9-opaqueDoubleResponse (0.00s)
        --- PASS: TestUnmarshal/9-opaqueDoubleResponse/unmarshal (0.00s)
        --- PASS: TestUnmarshal/9-opaqueDoubleResponse/remarshal (0.00s)
    --- PASS: TestUnmarshal/10-snmpv3HelloRequest (0.00s)
        --- PASS: TestUnmarshal/10-snmpv3HelloRequest/unmarshal (0.00s)
        --- PASS: TestUnmarshal/10-snmpv3HelloRequest/remarshal (0.00s)
    --- PASS: TestUnmarshal/11-snmpv3HelloResponse (0.00s)
        --- PASS: TestUnmarshal/11-snmpv3HelloResponse/unmarshal (0.00s)
        --- PASS: TestUnmarshal/11-snmpv3HelloResponse/remarshal (0.00s)
=== RUN   TestUnmarshalEmptyPanic
--- PASS: TestUnmarshalEmptyPanic (0.00s)
=== RUN   TestV3USMInitialPacket
--- PASS: TestV3USMInitialPacket (0.00s)
=== RUN   TestSendOneRequest_dups
--- PASS: TestSendOneRequest_dups (0.00s)
=== RUN   TestMarshalLength
--- PASS: TestMarshalLength (0.00s)
=== RUN   TestPartition
--- PASS: TestPartition (0.00s)
=== RUN   TestSnmpVersionString
--- PASS: TestSnmpVersionString (0.00s)
=== RUN   TestMD5HMAC
--- PASS: TestMD5HMAC (0.04s)
=== RUN   TestSHAHMAC
--- PASS: TestSHAHMAC (0.04s)
=== RUN   TestSendTrapBasic
    TestSendTrapBasic: trap_test.go:156: failing: due to changes in genlocalPrivKey
--- SKIP: TestSendTrapBasic (0.00s)
=== RUN   TestSendTrapWithoutWaitingOnListen
    TestSendTrapWithoutWaitingOnListen: trap_test.go:223: failing: due to changes in genlocalPrivKey
--- SKIP: TestSendTrapWithoutWaitingOnListen (0.00s)
=== RUN   TestSendV1Trap
    TestSendV1Trap: trap_test.go:303: failing: due to changes in genlocalPrivKey
--- SKIP: TestSendV1Trap (0.00s)
=== RUN   TestSendV3TrapNoAuthNoPriv
--- PASS: TestSendV3TrapNoAuthNoPriv (0.00s)
=== RUN   TestSendV3TrapMD5AuthNoPriv
--- PASS: TestSendV3TrapMD5AuthNoPriv (0.04s)
=== RUN   TestSendV3TrapSHAAuthNoPriv
--- PASS: TestSendV3TrapSHAAuthNoPriv (0.04s)
=== RUN   TestSendV3TrapSHAAuthDESPriv
--- PASS: TestSendV3TrapSHAAuthDESPriv (0.00s)
=== RUN   TestSendV3TrapSHAAuthAESPriv
--- PASS: TestSendV3TrapSHAAuthAESPriv (0.04s)
=== RUN   TestSendV3TrapSHAAuthAES192Priv
--- PASS: TestSendV3TrapSHAAuthAES192Priv (0.04s)
=== RUN   TestSendV3TrapSHAAuthAES192CPriv
--- PASS: TestSendV3TrapSHAAuthAES192CPriv (0.00s)
=== RUN   TestSendV3TrapSHAAuthAES256Priv
--- PASS: TestSendV3TrapSHAAuthAES256Priv (0.00s)
=== RUN   TestSendV3TrapSHAAuthAES256CPriv
--- PASS: TestSendV3TrapSHAAuthAES256CPriv (0.00s)
=== RUN   TestAuthenticationSHA224
--- PASS: TestAuthenticationSHA224 (0.04s)
=== RUN   TestIsAuthenticaSHA224
--- PASS: TestIsAuthenticaSHA224 (0.00s)
=== RUN   TestAuthenticationSHA512
--- PASS: TestAuthenticationSHA512 (0.04s)
=== RUN   TestIsAuthenticaSHA512
--- PASS: TestIsAuthenticaSHA512 (0.00s)
=== RUN   TestAPIConfigTypes
--- PASS: TestAPIConfigTypes (0.00s)
=== RUN   TestAPIDefault
--- PASS: TestAPIDefault (0.00s)
=== RUN   TestAPIConnectMethodSignature
--- PASS: TestAPIConnectMethodSignature (0.00s)
=== RUN   TestAPIGetMethodSignature
--- PASS: TestAPIGetMethodSignature (0.00s)
=== RUN   TestAPISetMethodSignature
--- PASS: TestAPISetMethodSignature (0.00s)
=== RUN   TestAPIGetNextMethodSignature
--- PASS: TestAPIGetNextMethodSignature (0.00s)
=== RUN   TestAPIBulkWalkMethodSignature
--- PASS: TestAPIBulkWalkMethodSignature (0.00s)
=== RUN   TestAPIBulkWalkAllMethodSignature
--- PASS: TestAPIBulkWalkAllMethodSignature (0.00s)
=== RUN   TestAPIWalkMethodSignature
--- PASS: TestAPIWalkMethodSignature (0.00s)
=== RUN   TestAPIWalkAllMethodSignature
--- PASS: TestAPIWalkAllMethodSignature (0.00s)
=== RUN   TestAPIWalkFuncSignature
--- PASS: TestAPIWalkFuncSignature (0.00s)
PASS
ok  	github.com/soniah/gosnmp	0.644s
```